### PR TITLE
BUGFIX: Compatibility with python 3.5 and below where json.loads will…

### DIFF
--- a/mediagrains/grain.py
+++ b/mediagrains/grain.py
@@ -23,6 +23,8 @@ directly by client code, but their documentation may be instructive.
 from __future__ import print_function
 from __future__ import absolute_import
 
+from six import string_types
+
 from uuid import UUID
 from nmoscommon.timestamp import Timestamp
 from collections import Sequence, MutableSequence, Mapping
@@ -465,6 +467,8 @@ append(path, pre=None, post=None)
 
     @data.setter
     def data(self, value):
+        if not isinstance(value, string_types):
+            value = value.decode('utf-8')
         value = json.loads(value)
         if 'type' not in value or 'topic' not in value or 'data' not in value:
             raise ValueError("incorrectly formated event payload")

--- a/tests/test_grain.py
+++ b/tests/test_grain.py
@@ -1443,9 +1443,9 @@ class TestGrain (TestCase):
         self.assertEqual(grain.event_type, "urn:x-ipstudio:format:event.query")
         self.assertEqual(grain.topic, "/dummy")
         self.assertEqual(grain.event_data, [])
-        self.assertEqual(json.loads(grain.data), {'type': "urn:x-ipstudio:format:event.query",
-                                                  'topic': "/dummy",
-                                                  'data': []})
+        self.assertEqual(json.loads(grain.data.decode('utf-8')), {'type': "urn:x-ipstudio:format:event.query",
+                                                                  'topic': "/dummy",
+                                                                  'data': []})
 
         self.assertEqual(repr(grain), "EventGrain({!r})".format(grain.meta))
 
@@ -1611,11 +1611,11 @@ class TestGrain (TestCase):
         self.assertEqual(grain.event_data[0], {'path': '/location',
                                                'pre': 'now',
                                                'post': 'next'})
-        self.assertEqual(json.loads(grain.data), {'type': "urn:x-ipstudio:format:event.potato",
-                                                  'topic': "/important/data",
-                                                  'data': [{'path': '/location',
-                                                            'pre': 'now',
-                                                            'post': 'next'}]})
+        self.assertEqual(json.loads(grain.data.decode('utf-8')), {'type': "urn:x-ipstudio:format:event.potato",
+                                                                  'topic': "/important/data",
+                                                                  'data': [{'path': '/location',
+                                                                            'pre': 'now',
+                                                                            'post': 'next'}]})
         grain.event_data[0]['post'] = 'never'
         del grain.event_data[0]['post']
         self.assertIsNone(grain.event_data[0].post)
@@ -1629,20 +1629,20 @@ class TestGrain (TestCase):
 
         grain.event_data = []
         self.assertEqual(len(grain.event_data), 0)
-        self.assertEqual(json.loads(grain.data), {'type': "urn:x-ipstudio:format:event.potato",
-                                                  'topic': "/important/data",
-                                                  'data': []})
+        self.assertEqual(json.loads(grain.data.decode('utf-8')), {'type': "urn:x-ipstudio:format:event.potato",
+                                                                  'topic': "/important/data",
+                                                                  'data': []})
 
         grain.data = json.dumps({'type': "urn:x-ipstudio:format:event.potato",
                                  'topic': "/important/data",
                                  'data': [{'path': '/location',
                                            'pre': 'now',
                                            'post': 'next'}]})
-        self.assertEqual(json.loads(grain.data), {'type': "urn:x-ipstudio:format:event.potato",
-                                                  'topic': "/important/data",
-                                                  'data': [{'path': '/location',
-                                                            'pre': 'now',
-                                                            'post': 'next'}]})
+        self.assertEqual(json.loads(grain.data.decode('utf-8')), {'type': "urn:x-ipstudio:format:event.potato",
+                                                                  'topic': "/important/data",
+                                                                  'data': [{'path': '/location',
+                                                                            'pre': 'now',
+                                                                            'post': 'next'}]})
 
         with self.assertRaises(ValueError):
-            grain.data = json.dumps({'potato': "masher"})
+            grain.data = bytearray(json.dumps({'potato': "masher"}).encode('utf-8'))


### PR DESCRIPTION
… not accept a bytes-like object as a parameter

Finishes #155436163