### PR TITLE
position stream pointer at end of grain when skip_data=True

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Mediagrains Library Changelog
 
+## 1.1.0
+- GSFDecoder.grains() with skip_data=True positions stream pointer after data before yielding
+
 ## 1.0.0
 - Initial Release version
 

--- a/mediagrains/gsf.py
+++ b/mediagrains/gsf.py
@@ -604,6 +604,8 @@ class GSFDecoder(object):
     def grains(self, skip_data=False):
         """Generator to get grains from the GSF file. Skips blocks which aren't "grai".
 
+        The file_data will be positioned after the `grai` block.
+
         :param skip_data: If True, grain data blocks will be seeked over and only grain headers will be read
         :yields: (Grain, local_id) tuple for each grain
         :raises GSFDecodeError: If grain is invalid (e.g. no "gbhd" child)
@@ -625,7 +627,7 @@ class GSFDecoder(object):
                             if grdt_block.get_remaining() > 0 and not skip_data:
                                 data = self.file_data.read(grdt_block.get_remaining())
 
-                    yield (self.Grain(meta, data), local_id)
+                yield (self.Grain(meta, data), local_id)
             except EOFError:
                 return  # We ran out of grains to read and hit EOF
 

--- a/mediagrains/gsf.py
+++ b/mediagrains/gsf.py
@@ -620,9 +620,9 @@ class GSFDecoder(object):
 
                     data = None
 
-                    if grai_block.has_child_block() and not skip_data:
+                    if grai_block.has_child_block():
                         with GSFBlock(self.file_data, want_tag="grdt") as grdt_block:
-                            if grdt_block.get_remaining() > 0:
+                            if grdt_block.get_remaining() > 0 and not skip_data:
                                 data = self.file_data.read(grdt_block.get_remaining())
 
                     yield (self.Grain(meta, data), local_id)

--- a/setup.py
+++ b/setup.py
@@ -55,7 +55,7 @@ packages_required = [
 deps_required = []
 
 setup(name="mediagrains",
-      version="1.0.0",
+      version="1.1.0",
       description="Simple utility for grain-based media",
       url='https://github.com/bbc/rd-apmm-python-lib-mediagrains',
       author='James Weaver',


### PR DESCRIPTION
This means that a stream tell() after a grain was yielded by GSFDecoder.grains() will report the position at the end of the grain rather than at the end of the header blocks. This provides a way to get the grain size.