### PR TITLE
clear grains after write

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Mediagrains Library Changelog
 
+## 2.0.0
+- GSFEncoder does not buffer grains once they have been written
+- GSFEncoderSegment does not provide access to buffered grains
+
 ## 1.1.1
 - Updated README.md
 

--- a/setup.py
+++ b/setup.py
@@ -55,7 +55,7 @@ packages_required = [
 deps_required = []
 
 setup(name="mediagrains",
-      version="1.1.1",
+      version="2.0.0",
       description="Simple utility for grain-based media",
       url='https://github.com/bbc/rd-apmm-python-lib-mediagrains',
       author='James Weaver',

--- a/tests/test_gsf.py
+++ b/tests/test_gsf.py
@@ -640,7 +640,7 @@ class TestGSFDumps(TestCase):
 
         enc.add_grain(grain0, segment_local_id=2)
 
-        self.assertEqual(enc.segments[2].grains[0], grain0)
+        self.assertEqual(enc.segments[2]._grains[0], grain0)
 
 
 class TestGSFBlock(TestCase):


### PR DESCRIPTION
GSFEncoder does not buffer grains once they have been written. GSFEncoderSegment does not provide access to buffered grains.
