### PR TITLE
Accept a TimeOffset for a grain timestamp

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Mediagrains Library Changelog
 
+## 2.0.1
+- Accept TimeOffsets as grain timestamps, to work around oddities in JSON
+  parsing behaviour.
+
 ## 2.0.0
 - GSFEncoder does not buffer grains once they have been written
 - GSFEncoderSegment does not provide access to buffered grains

--- a/mediagrains/grain.py
+++ b/mediagrains/grain.py
@@ -214,7 +214,7 @@ final_origin_timestamp()
 
     @origin_timestamp.setter
     def origin_timestamp(self, value):
-        if isinstance(value, Timestamp):
+        if isinstance(value, TimeOffset):
             value = value.to_tai_sec_nsec()
         self.meta['grain']['origin_timestamp'] = value
 
@@ -227,7 +227,7 @@ final_origin_timestamp()
 
     @sync_timestamp.setter
     def sync_timestamp(self, value):
-        if isinstance(value, Timestamp):
+        if isinstance(value, TimeOffset):
             value = value.to_tai_sec_nsec()
         self.meta['grain']['sync_timestamp'] = value
 
@@ -237,7 +237,7 @@ final_origin_timestamp()
 
     @creation_timestamp.setter
     def creation_timestamp(self, value):
-        if isinstance(value, Timestamp):
+        if isinstance(value, TimeOffset):
             value = value.to_tai_sec_nsec()
         self.meta['grain']['creation_timestamp'] = value
 

--- a/mediagrains/grain.py
+++ b/mediagrains/grain.py
@@ -215,7 +215,9 @@ final_origin_timestamp()
     @origin_timestamp.setter
     def origin_timestamp(self, value):
         if isinstance(value, TimeOffset):
-            value = value.to_tai_sec_nsec()
+            if value.sign < 0:
+                raise ValueError("Grain timestamps cannot be negative")
+            value = value.to_sec_nsec()
         self.meta['grain']['origin_timestamp'] = value
 
     def final_origin_timestamp(self):
@@ -228,7 +230,9 @@ final_origin_timestamp()
     @sync_timestamp.setter
     def sync_timestamp(self, value):
         if isinstance(value, TimeOffset):
-            value = value.to_tai_sec_nsec()
+            if value.sign < 0:
+                raise ValueError("Grain timestamps cannot be negative")
+            value = value.to_sec_nsec()
         self.meta['grain']['sync_timestamp'] = value
 
     @property
@@ -238,7 +242,9 @@ final_origin_timestamp()
     @creation_timestamp.setter
     def creation_timestamp(self, value):
         if isinstance(value, TimeOffset):
-            value = value.to_tai_sec_nsec()
+            if value.sign < 0:
+                raise ValueError("Grain timestamps cannot be negative")
+            value = value.to_sec_nsec()
         self.meta['grain']['creation_timestamp'] = value
 
     @property

--- a/setup.py
+++ b/setup.py
@@ -55,7 +55,7 @@ packages_required = [
 deps_required = []
 
 setup(name="mediagrains",
-      version="2.0.0",
+      version="2.0.1",
       description="Simple utility for grain-based media",
       url='https://github.com/bbc/rd-apmm-python-lib-mediagrains',
       author='James Weaver',

--- a/tests/test_grain.py
+++ b/tests/test_grain.py
@@ -217,6 +217,23 @@ class TestGrain (TestCase):
         ])
         self.assertEqual(repr(grain), "Grain({!r})".format(meta))
 
+    def test_empty_grain_negative_time_exception(self):
+        """Test that setting negative timestamps raises an exception"""
+        cts = Timestamp.from_tai_sec_nsec("417798915:0")
+        meta = {}
+
+        with mock.patch.object(Timestamp, "get_time", return_value=cts):
+            grain = Grain(meta)
+
+        with self.assertRaises(ValueError):
+            grain.origin_timestamp = TimeOffset.from_str("-200:50")
+
+        with self.assertRaises(ValueError):
+            grain.sync_timestamp = TimeOffset.from_str("-200:50")
+
+        with self.assertRaises(ValueError):
+            grain.creation_timestamp = TimeOffset.from_str("-200:50")
+
     def test_empty_grain_setters(self):
         src_id = uuid.UUID("f18ee944-0841-11e8-b0b0-17cef04bd429")
         flow_id = uuid.UUID("f79ce4da-0841-11e8-9a5b-dfedb11bafeb")


### PR DESCRIPTION
Occasionally we end up with a `TimeOffset` instead of a `Timestamp` for a grain timestamp - mostly because mediajson can't discriminate between them when parsing it's own output.

Rather than changing mediatimestamp or mediajson, this works around that problem by accepting any `TimeOffset` derivative as being a `Timestamp`

Pivotal [#161255149](https://www.pivotaltracker.com/story/show/161255149)