### PR TITLE
Allow build to run on more agents, fix linting

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Mediagrains Library Changelog
 
+## 2.3.3
+- Allow build to run on a wider selection of agents.
+
 ## 2.3.2
 - Added Jenkins trigger to rebuild master every day.
 

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -16,7 +16,7 @@
 
 pipeline {
     agent {
-        label "16.04&&ipstudio-deps"
+        label "ubuntu&&apmm-slave"
     }
     options {
         ansiColor('xterm') // Add support for coloured output

--- a/mediagrains/hypothesis/strategies.py
+++ b/mediagrains/hypothesis/strategies.py
@@ -533,7 +533,7 @@ def event_grains(src_id=None,
                        will use lists(fixed_dictionaries({'path': from_regex(r'^[a-zA-Z0-9_\-]+[a-zA-Z0-9_\-/]*$'),
                                                           'pre': one_of(integers(), booleans(), fraction_dicts(), timestamps()),
                                                           'post': one_of(integers(), booleans(), fraction_dicts(), timestamps())}))
-    """
+    """  # noqa W605 Ignore invalid escape sequence in docstring
     if rate is DONOTSET:
         rate = Fraction(25, 1)
     if duration is DONOTSET:

--- a/setup.py
+++ b/setup.py
@@ -55,7 +55,7 @@ packages_required = [
 deps_required = []
 
 setup(name="mediagrains",
-      version="2.3.2",
+      version="2.3.3",
       description="Simple utility for grain-based media",
       url='https://github.com/bbc/rd-apmm-python-lib-mediagrains',
       author='James Weaver',


### PR DESCRIPTION
Allows the build to run on the APMM slaves, and fixes a linting issue that arises as a result.

PR question: Is this a sensible way to suppress that warning; since it's a triple-quoted string serving as a comment.