### PR TITLE
fix restore bytestream pos when lazy loading

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Mediagrains Library Changelog
 
+## 2.5.1
+- Fix restoring bytestream position when lazy loading bytes.
+
 ## 2.5.0
 - Added ability to filter GSFDecoder output based on local ids
 

--- a/mediagrains/utils/iobytes.py
+++ b/mediagrains/utils/iobytes.py
@@ -139,9 +139,12 @@ class IOBytes (LazyLoader, Sequence):
         :param start: The length of the data
         """
         def __loadbytes():
-            loc = self._istream.seek(self._start)
-            _bytes = self._istream.read(self._length)
-            self._istream.seek(loc)
+            loc = self._istream.tell()
+            try:
+                self._istream.seek(self._start)
+                _bytes = self._istream.read(self._length)
+            finally:
+                self._istream.seek(loc)
             return _bytes
 
         LazyLoader.__init__(self, __loadbytes)

--- a/setup.py
+++ b/setup.py
@@ -55,7 +55,7 @@ packages_required = [
 deps_required = []
 
 setup(name="mediagrains",
-      version="2.5.0",
+      version="2.5.1",
       description="Simple utility for grain-based media",
       url='https://github.com/bbc/rd-apmm-python-lib-mediagrains',
       author='James Weaver',

--- a/tests/test_iobytes.py
+++ b/tests/test_iobytes.py
@@ -40,10 +40,12 @@ class TestIOBytes (TestCase):
     @given(integers(min_value=0, max_value=65535), integers(min_value=0, max_value=65535))
     def test_read(self, start, length):
         iostream = BytesIO(TEST_DATA)
+        orig_loc = iostream.tell()
         iobytes = IOBytes(iostream, start, length)
         data = binary_type(iobytes)
         self.assertEqual(len(data), length)
         self.assertEqual(data, TEST_DATA[start:start + length])
+        self.assertEqual(orig_loc, iostream.tell())
 
     def test_noread(self):
         iostream = mock.MagicMock()


### PR DESCRIPTION
Issue was that _iostream.seek() returns the post-seek position, not the pre-seek position.