### PR TITLE
Bugfixes for 2.7.0 which correct errors in downstream package builds

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Mediagrains Library Changelog
 
+## 2.7.1
+- Bugfix: Restore behaviour whereby `gsf.GSFEncoder.dump` calls `gsf.GSFEncoder.start_dump` and `gsf.GSFEncoder.end_dump`
+  (this matters if subclasses have overridden these methods)
+
 ## 2.7.0
 - Dropped all support for Python2.7
 - Moved python3.6 specific submodules in tree

--- a/mediagrains/gsf.py
+++ b/mediagrains/gsf.py
@@ -1514,8 +1514,8 @@ class GSFEncoder(object):
     def dump(self):
         """Dump the whole contents of this encoder to the file in one go,
         replacing anything that's already there."""
-        with self:
-            pass
+        self.start_dump(all_at_once=True)
+        self.end_dump(all_at_once=True)
 
     @deprecated(version="2.7.0", reason="This mechanism is deprecated, use a context manager instead")
     def start_dump(self, all_at_once=False):

--- a/setup.py
+++ b/setup.py
@@ -48,7 +48,7 @@ console_scripts = [
 ]
 
 setup(name="mediagrains",
-      version="2.7.0",
+      version="2.7.1",
       python_requires='>=3.6.0',
       description="Simple utility for grain-based media",
       url='https://github.com/bbc/rd-apmm-python-lib-mediagrains',


### PR DESCRIPTION
Fixes cloudagnostic build error caused by `end_dump` not being called.