### PR TITLE
v2.8.1.dev1: Added bypass for timing irregularity in GSF Decoder

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,9 +1,13 @@
 # Mediagrains Library Changelog
 
+## 2.8.1
+- Added a bypass so that when wrapping a BytesIO in an Async wrapper unnecessary and potentially costly threads aren't spawned
+
 ## 2.8.0
 - Switched to using asynctest for testing asynchronous code
 - Made asynchronous IO wrappers that wrap synchronous IO do so using an executor thread pool
 - Added support for automatically wrapping synchronous files in asynchronous wrappers to use them in gsf encoder
+- Added bypass to wrap BytesIO in a lighter weight wrapper to prevent timing irregularities
 
 ## 2.7.2
 - Bugfix: Restore behaviour whereby grains can be added to a segment object during an active progressive encode

--- a/mediagrains/gsf.py
+++ b/mediagrains/gsf.py
@@ -54,7 +54,7 @@ from .typing import GrainMetadataDict, GrainDataParameterType, RationalTypes
 
 from .grain import GRAIN, VIDEOGRAIN, EVENTGRAIN, AUDIOGRAIN, CODEDAUDIOGRAIN, CODEDVIDEOGRAIN
 
-from .utils.asyncbinaryio import AsyncBinaryIO, OpenAsyncBinaryIO, AsyncFileWrapper, OpenAsyncFileWrapper
+from .utils.asyncbinaryio import AsyncBinaryIO, OpenAsyncBinaryIO, AsyncFileWrapper, OpenAsyncFileWrapper, AsyncBytesIOWrapper
 
 from contextlib import contextmanager
 
@@ -862,6 +862,9 @@ class GSFDecoder(object):
         elif isinstance(file_data, OpenAsyncBinaryIO):
             self._afile_data = None
             self._open_afile = file_data
+        elif isinstance(file_data, BytesIO):
+            self._afile_data = AsyncBytesIOWrapper(file_data)
+            self._open_afile = None
         elif isinstance(file_data, (RawIOBase, BufferedIOBase)):
             self._afile_data = AsyncFileWrapper(file_data)
             self._open_afile = None

--- a/mediagrains/utils/asyncbinaryio.py
+++ b/mediagrains/utils/asyncbinaryio.py
@@ -21,7 +21,7 @@ interface a little.
 """
 
 from abc import ABCMeta, abstractmethod
-from io import SEEK_SET, SEEK_CUR
+from io import SEEK_SET, SEEK_CUR, BytesIO
 
 from typing import Type, Union, Optional, IO, cast, TypeVar, Callable, Coroutine
 from io import RawIOBase, UnsupportedOperation
@@ -260,6 +260,60 @@ class AsyncFileWrapper(AsyncBinaryIO):
     def __init__(self, fp: IO[bytes]):
         super().__init__(cls=OpenAsyncFileWrapper, fp=fp)
         self._inst: OpenAsyncFileWrapper
+        self.fp = fp
+
+
+class OpenAsyncBytesIOWrapper(OpenAsyncBinaryIO):
+    def __init__(self, fp: BytesIO):
+        self.fp = cast(RawIOBase, fp)
+
+    async def __open__(self) -> None:
+        pass
+
+    async def __close__(self) -> None:
+        pass
+
+    async def read(self, s: int = -1) -> bytes:
+        while True:
+            r = self.fp.read(s)
+            if r is not None:
+                return r
+
+    async def readinto(self, b: bytearray) -> Optional[int]:
+        return self.fp.readinto(b)
+
+    async def readall(self) -> bytes:
+        return self.fp.readall()
+
+    async def write(self, b: bytes) -> Optional[int]:
+        return self.fp.write(b)
+
+    async def truncate(self, size: Optional[int] = None) -> int:
+        return self.fp.truncate(size)
+
+    def tell(self) -> int:
+        return self.fp.tell()
+
+    def seek(self, offset: int, whence: int = SEEK_SET):
+        return self.fp.seek(offset, whence)
+
+    def seekable(self) -> bool:
+        return self.fp.seekable()
+
+    def readable(self) -> bool:
+        return self.fp.readable()
+
+    def writable(self) -> bool:
+        return self.fp.writable()
+
+    def getsync(self) -> IO[bytes]:
+        return cast(IO[bytes], self.fp)
+
+
+class AsyncBytesIOWrapper(AsyncBinaryIO):
+    def __init__(self, fp: BytesIO):
+        super().__init__(cls=OpenAsyncBytesIOWrapper, fp=fp)
+        self._inst: OpenAsyncBytesIOWrapper
         self.fp = fp
 
 

--- a/setup.py
+++ b/setup.py
@@ -48,7 +48,7 @@ console_scripts = [
 ]
 
 setup(name="mediagrains",
-      version="2.8.0",
+      version="2.8.1",
       python_requires='>=3.6.0',
       description="Simple utility for grain-based media",
       url='https://github.com/bbc/rd-apmm-python-lib-mediagrains',


### PR DESCRIPTION
This adds a bypass so that expensive threads aren't spawned when wrapping a BytesIO object in an Async Wrapper

This build is a version of magpie which manually pulls in this branch into its tox environment, in order to demonstrate that it fixes some test timing irregularities:

https://jenkins.rd.bbc.co.uk/job/apmm-repos/job/rd-cloudfit-magpie-ingest-service/job/jamesba-pullinmodifiedmediagrains/1/console