### PR TITLE
Reinstante synchronous decode codepath

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Mediagrains Library Changelog
 
+## 2.8.2
+- Removed code that used asyncio in synchronous calls to decode gsf and replaced it with a purely synchronous version.
+  It turned out that since asyncio is fundementally incompatible with some third party libraries (eg. gevent) we need
+  a code path that doesn't make any use of it.
+
 ## 2.8.1
 - Added a bypass so that when wrapping a BytesIO in an Async wrapper unnecessary and potentially costly threads aren't spawned
 

--- a/setup.py
+++ b/setup.py
@@ -48,7 +48,7 @@ console_scripts = [
 ]
 
 setup(name="mediagrains",
-      version="2.8.1",
+      version="2.8.2",
       python_requires='>=3.6.0',
       description="Simple utility for grain-based media",
       url='https://github.com/bbc/rd-apmm-python-lib-mediagrains',


### PR DESCRIPTION
This leads to a lot of code near duplication, and will eventually need to be removed by refactoring the decode code to split IO and processing more directly from each other.