### PR TITLE
Fix numpy VideoGrain.length to be the byte length

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Mediagrains Library Changelog
 
+## 2.8.3
+- Bugfix: Numpy VideoGrain length should be the bytes length, not the array length.
+
 ## 2.8.2
 - Removed code that used asyncio in synchronous calls to decode gsf and replaced it with a purely synchronous version.
   It turned out that since asyncio is fundementally incompatible with some third party libraries (eg. gevent) we need

--- a/mediagrains/numpy/videograin.py
+++ b/mediagrains/numpy/videograin.py
@@ -246,6 +246,15 @@ class VIDEOGRAIN (bytesgrain.VIDEOGRAIN):
             self.component_data = ComponentDataList([])
 
     @property
+    def length(self) -> int:
+        return self._data.nbytes
+
+    @length.setter
+    def length(self, L: int) -> None:
+        # Get the length Property from the parent class and set the new value L
+        super(VIDEOGRAIN, type(self)).length.fset(self, L)  # type: ignore
+
+    @property
     def data(self) -> np.ndarray:
         return self._data
 

--- a/setup.py
+++ b/setup.py
@@ -48,7 +48,7 @@ console_scripts = [
 ]
 
 setup(name="mediagrains",
-      version="2.8.2",
+      version="2.8.3",
       python_requires='>=3.6.0',
       description="Simple utility for grain-based media",
       url='https://github.com/bbc/rd-apmm-python-lib-mediagrains',

--- a/tests/test_numpy_videograin.py
+++ b/tests/test_numpy_videograin.py
@@ -28,6 +28,7 @@ from mediagrains.cogenums import (
     COG_FRAME_IS_PLANAR,
     COG_FRAME_IS_PLANAR_RGB,
     COG_FRAME_FORMAT_ACTIVE_BITS)
+from mediagrains import grain_constructors as bytesgrain_constructors
 from mediatimestamp.immutable import Timestamp, TimeRange
 from fractions import Fraction
 from copy import copy, deepcopy
@@ -726,3 +727,16 @@ class TestGrain (TestCase):
         grain.data[0] = 0xCAFE
 
         self.assertNotEqual(grain.data[0], clone.data[0])
+
+    def test_length(self):
+        """Check that the length override provides the length in bytes"""
+        src_id = uuid.UUID("f18ee944-0841-11e8-b0b0-17cef04bd429")
+        flow_id = uuid.UUID("f79ce4da-0841-11e8-9a5b-dfedb11bafeb")
+        cts = Timestamp.from_tai_sec_nsec("417798915:0")
+        with mock.patch.object(Timestamp, "get_time", return_value=cts):
+            grain = bytesgrain_constructors.VideoGrain(src_id, flow_id,
+                                                       cog_frame_format=CogFrameFormat.S16_422_10BIT,
+                                                       width=480, height=270)
+            np_grain = VideoGrain(grain).convert(CogFrameFormat.v210)
+
+        self.assertEqual(np_grain.length, (480+47)//48*128*270)


### PR DESCRIPTION
This issue resulted in a grain converted to v210 and written to GSF to have an incorrect size in the `grdt` block header.

The `# type: ignore` was required because mypy reported `mediagrains/numpy/videograin.py:254: error: overloaded function has no attribute "fset"`. There is an open mypy issue related to this: https://github.com/python/mypy/issues/6045.

Found as part of pivotal job https://www.pivotaltracker.com/story/show/169632693