### PR TITLE
Add flag for comparing grains pairwise without retaining all in memory

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,8 @@
 # Mediagrains Library Changelog
 
-## 2.8.4 (Under Construction)
+## 2.9.0 (Under Construction)
 - Added CogAudioFormat.UNKNOWN which was erroneously missing from enum
+- Add a flag for compairing grain iterators without retaining all grains in memory.
 
 ## 2.8.3
 - Bugfix: Numpy VideoGrain length should be the bytes length, not the array length.

--- a/mediagrains/comparison/__init__.py
+++ b/mediagrains/comparison/__init__.py
@@ -65,7 +65,7 @@ def compare_grain(a, b, *options):
     return GrainComparisonResult("{}", a, b, options=options)
 
 
-def compare_grains_pairwise(a, b, *options):
+def compare_grains_pairwise(a, b, *options, return_last_only=False):
     """
     Compare two iterators which produce grains pairwise. Each grain from iterator a will be compared against the corresponding grain in iterator b. The
     comparison will end when any grain fails to match. If one iterator runs out of grains the comparison will end. If both run out at the same time and
@@ -73,6 +73,9 @@ def compare_grains_pairwise(a, b, *options):
 
     :param a: An iterator that generates grains
     :param b: An iterator that generates grains
+    :param return_last_only: Set to True to return only the description of the last comparison, instead of all
+                             comparisons performed. If False, all compared Grains will be retained, which may require
+                             significant memory if the Grain iterators are long.
     :param *options: Additional arguments are passed to the grain comparison mechanism exactly as for compare_grains.
 
     :returns: An object which will evaluate as True if the iterators matched, and False if they did not. In addition it has a rich description of the
@@ -83,4 +86,4 @@ def compare_grains_pairwise(a, b, *options):
     By default all comparisons ignore differences in creation_timestamp, to force this timestamp to be checked use the options.Include.creation_timestamp
     option.
     """
-    return GrainIteratorComparisonResult("{}", a, b, options=options)
+    return GrainIteratorComparisonResult("{}", a, b, return_last_only=return_last_only, options=options)

--- a/mediagrains/comparison/_internal.py
+++ b/mediagrains/comparison/_internal.py
@@ -13,6 +13,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
+from typing import Iterable, List, Tuple
+from ..grain import GRAIN
 
 from mediatimestamp.immutable import TimeOffset
 from difflib import SequenceMatcher
@@ -425,18 +427,23 @@ class OrderedContainerComparisonResult(ComparisonResult):
 
 
 class GrainIteratorComparisonResult(ComparisonResult):
-    def __init__(self, identifier, a, b, return_last_only=False, **kwargs):
+    def __init__(self,
+                 identifier: str,
+                 a: Iterable[GRAIN],
+                 b: Iterable[GRAIN],
+                 return_last_only: bool = False,
+                 **kwargs):
         self.return_last_only = return_last_only
         super(GrainIteratorComparisonResult, self).__init__(identifier, a, b, **kwargs)
 
-    def compare(self, a, b):
+    def compare(self, a: Iterable[GRAIN], b: Iterable[GRAIN]) -> Tuple[bool, str, List[ComparisonResult]]:
         a = iter(a)
         b = iter(b)
 
-        self.compared_item_count = 0
+        self.compared_item_count: int = 0
         all_success = True
 
-        children = []
+        children: List[ComparisonResult] = []
 
         while True:
             A = next(a, None)
@@ -481,7 +488,7 @@ class GrainIteratorComparisonResult(ComparisonResult):
                 children
             )
 
-    def __len__(self):
+    def __len__(self) -> int:
         return self.compared_item_count
 
 

--- a/setup.py
+++ b/setup.py
@@ -48,7 +48,7 @@ console_scripts = [
 ]
 
 setup(name="mediagrains",
-      version="2.8.4.dev1",
+      version="2.9.0.dev1",
       python_requires='>=3.6.0',
       description="Simple utility for grain-based media",
       url='https://github.com/bbc/rd-apmm-python-lib-mediagrains',


### PR DESCRIPTION
Adds a `return_last_only` flag to `compare_grains_pairwise` (defaulting to False), which if set will only retain the last child comparison, allowing the other grain data to be freed.

Also adds some unit tests for pairwise comparison.

Part of Pivotal [#170747842](https://www.pivotaltracker.com/story/show/170747842)