### PR TITLE
Write correct number of samples to audio grains

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Mediagrains Library Changelog
 
+## 2.9.1
+- Fix a bug where the `--samples_per_grain` option in `wrap_audio_in_gsf` wasn't honoured.
+
 ## 2.9.0
 - Added CogAudioFormat.UNKNOWN which was erroneously missing from enum
 - Add a flag for compairing grain iterators without retaining all grains in memory.

--- a/mediagrains/tools/wrap_in_gsf.py
+++ b/mediagrains/tools/wrap_in_gsf.py
@@ -19,6 +19,7 @@
 import uuid
 import argparse
 import sys
+import fractions
 
 from mediatimestamp.immutable import Timestamp
 
@@ -127,9 +128,11 @@ def wrap_audio_in_gsf():
     flow_id = args.flow_id if args.flow_id else uuid.uuid4()
     source_id = args.source_id if args.source_id else uuid.uuid4()
 
+    grain_rate = fractions.Fraction(args.sample_rate, args.samples_per_grain)
+
     template_grain = AudioGrain(
-        flow_id=flow_id, source_id=source_id, origin_timestamp=args.start_ts, rate=args.sample_rate,
-        channels=args.channels, samples=args.samples_per_grain, cog_audio_format=args.format
+        flow_id=flow_id, source_id=source_id, origin_timestamp=args.start_ts, sample_rate=args.sample_rate,
+        rate=grain_rate, channels=args.channels, samples=args.samples_per_grain, cog_audio_format=args.format
     )
 
     wrap_to_gsf(input_file=args.input_file, output_file=args.output_file, template_grain=template_grain)

--- a/setup.py
+++ b/setup.py
@@ -48,7 +48,7 @@ console_scripts = [
 ]
 
 setup(name="mediagrains",
-      version="2.9.0",
+      version="2.9.1",
       python_requires='>=3.6.0',
       description="Simple utility for grain-based media",
       url='https://github.com/bbc/rd-apmm-python-lib-mediagrains',


### PR DESCRIPTION
Fixes a bug in `wrap_audio_in_gsf` where the `--samples_per_grain` flag wasn't used to calculate the grain rate, and as a result one sample was written to every grain.

Version bump: 2.9.1

Pivotal [#172351376](https://www.pivotaltracker.com/story/show/172351376)