### PR TITLE
Added tests for gsf encodability of numpy grains

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -48,7 +48,7 @@ console_scripts = [
 ]
 
 setup(name="mediagrains",
-      version="2.9.1",
+      version="2.9.1.post1",
       python_requires='>=3.6.0',
       description="Simple utility for grain-based media",
       url='https://github.com/bbc/rd-apmm-python-lib-mediagrains',


### PR DESCRIPTION
Part of Job: https://www.pivotaltracker.com/story/show/172248289