### PR TITLE
Handle EOFError when wrapping content in GSF

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Mediagrains Library Changelog
 
+## 2.9.3
+- Handle EOFError in `wrap_in_gsf` command line tools.
+
 ## 2.9.2
 - Allow stdin as a valid input file for the tools
 

--- a/mediagrains/utils/grain_wrapper.py
+++ b/mediagrains/utils/grain_wrapper.py
@@ -55,7 +55,10 @@ class GrainWrapper(object):
             new_grain = copy.deepcopy(self.template_grain)
             new_grain.origin_timestamp = timestamp
 
-            grain_data = self.input_data.read(self.frame_size)
+            try:
+                grain_data = self.input_data.read(self.frame_size)
+            except EOFError:
+                break
 
             if grain_data:
                 new_grain.data = grain_data

--- a/setup.py
+++ b/setup.py
@@ -48,7 +48,7 @@ console_scripts = [
 ]
 
 setup(name="mediagrains",
-      version="2.9.2",
+      version="2.9.3",
       python_requires='>=3.6.0',
       description="Simple utility for grain-based media",
       url='https://github.com/bbc/rd-apmm-python-lib-mediagrains',


### PR DESCRIPTION
Fixes a bug where `wrap_video_in_gsf` and `wrap_audio_in_gsf` fail because they don't expect an `EOFError` when the input runs out of data.

Should this be v2.9.3 or is this a sensible use of a post-release? Should it get a changelog entry?