### PR TITLE
Use agents from the apmm-agent group

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -16,7 +16,7 @@
 
 pipeline {
     agent {
-        label "ubuntu&&apmm-slave&&18.04"
+        label "ubuntu&&apmm-agent&&18.04"
     }
     options {
         ansiColor('xterm') // Add support for coloured output

--- a/setup.py
+++ b/setup.py
@@ -48,7 +48,7 @@ console_scripts = [
 ]
 
 setup(name="mediagrains",
-      version="2.12.1",
+      version="2.12.1.post1",
       python_requires='>=3.6.0',
       description="Simple utility for grain-based media",
       url='https://github.com/bbc/rd-apmm-python-lib-mediagrains',


### PR DESCRIPTION
Replaces `apmm-slave` with the identical `apmm-agent` to remove problematic terminology.
Mostly to sanity check that I need to do a `.post` version here because otherwise CI will fail when it tries to upload to PyPI?

https://www.pivotaltracker.com/story/show/174067275