### PR TITLE
Fix test signal for 24-bit planar data

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Mediagrains Library Changelog
 
+## 2.14.2
+- Fix 24-bit planar audio test signal that should occupy 32-bits.
+
 ## 2.14.1
 - Fix unbounded timerange in legacy test signal generators.
 

--- a/mediagrains/patterngenerators/audio/tone.py
+++ b/mediagrains/patterngenerators/audio/tone.py
@@ -92,11 +92,14 @@ class Tone(AudioPatternGenerator):
                                          CogAudioFormat.S16_INTERLEAVED]:
                 formatted_sample_data = [round(x*self.volume*(1 << 15)) for x in self._sample_values]
                 depth = 16
-            elif self.cog_audio_format in [CogAudioFormat.S24_PLANES,
-                                           CogAudioFormat.S24_PAIRS,
+            elif self.cog_audio_format in [CogAudioFormat.S24_PAIRS,
                                            CogAudioFormat.S24_INTERLEAVED]:
                 formatted_sample_data = [round(x*self.volume*(1 << 23)) for x in self._sample_values]
                 depth = 24
+            elif self.cog_audio_format in [CogAudioFormat.S24_PLANES]:
+                # signed 24-bit occupies lower part of unsigned 32-bit
+                formatted_sample_data = [((round(x*self.volume*(1 << 31))+2**32) >> 8) & 0x00ffffff for x in self._sample_values]
+                depth = 32
             elif self.cog_audio_format in [CogAudioFormat.S32_PLANES,
                                            CogAudioFormat.S32_PAIRS,
                                            CogAudioFormat.S32_INTERLEAVED]:

--- a/mediagrains/testsignalgenerator.py
+++ b/mediagrains/testsignalgenerator.py
@@ -254,11 +254,14 @@ def AudioGrainsLoopingData(src_id, flow_id,
                             CogAudioFormat.S16_INTERLEAVED]:
         formatted_sample_data = [round(x*volume*(1 << 15)) for x in sample_data]
         depth = 16
-    elif cog_audio_format in [CogAudioFormat.S24_PLANES,
-                              CogAudioFormat.S24_PAIRS,
+    elif cog_audio_format in [CogAudioFormat.S24_PAIRS,
                               CogAudioFormat.S24_INTERLEAVED]:
         formatted_sample_data = [round(x*volume*(1 << 23)) for x in sample_data]
         depth = 24
+    elif cog_audio_format in [CogAudioFormat.S24_PLANES]:
+        # signed 24-bit occupies lower part of unsigned 32-bit
+        formatted_sample_data = [((round(x*volume*(1 << 31))+2**32) >> 8) & 0x00ffffff for x in sample_data]
+        depth = 32
     elif cog_audio_format in [CogAudioFormat.S32_PLANES,
                               CogAudioFormat.S32_PAIRS,
                               CogAudioFormat.S32_INTERLEAVED]:

--- a/setup.py
+++ b/setup.py
@@ -51,7 +51,7 @@ console_scripts = [
 ]
 
 setup(name="mediagrains",
-      version="2.14.1.post1",
+      version="2.14.2",
       python_requires='>=3.6.0',
       description="Simple utility for grain-based media",
       url='https://github.com/bbc/rd-apmm-python-lib-mediagrains',


### PR DESCRIPTION
Cog 24-bit planar audio data is stored in 4 bytes rather than 3. Only the lower 3 bytes are occupied.