### PR TITLE
Fix seek and tell to be relative to the correct current position

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Mediagrains Library Changelog
 
+## 2.15.1
+- BugFix: fix seek and tell in OpenAsyncStreamWrapper to be relative to the correct current position.
+
 ## 2.15.0
 - Add support for H.264 (`--format H264`) to the `wrap_video_in_gsf` tool.
 

--- a/mediagrains/utils/asyncbinaryio.py
+++ b/mediagrains/utils/asyncbinaryio.py
@@ -338,7 +338,7 @@ class OpenAsyncStreamWrapper(OpenAsyncBinaryIO):
                 await self.reader.read(self._next_pos - self._pos)
             if self.writer is not None:
                 self.writer.write(bytes(self._next_pos - self._pos))
-        self._pos = self._next_pos
+            self._pos = self._next_pos
 
     async def read(self, s: int = -1) -> bytes:
         if self.reader is None:
@@ -378,10 +378,19 @@ class OpenAsyncStreamWrapper(OpenAsyncBinaryIO):
         raise UnsupportedOperation("Cannot truncate a network stream")
 
     def tell(self) -> int:
-        return self._pos
+        if self._next_pos > self._pos:
+            # use self._next_pos as the base position as self._pos has not been aligned after a seek
+            return self._next_pos
+        else:
+            return self._pos
 
     def seek(self, offset: int, whence: int = SEEK_SET):
-        next_pos = self._next_pos
+        if self._next_pos > self._pos:
+            # use self._next_pos as the base position as self._pos has not been aligned after a seek
+            next_pos = self._next_pos
+        else:
+            next_pos = self._pos
+
         if whence == SEEK_SET:
             next_pos = offset
         elif whence == SEEK_CUR:

--- a/setup.py
+++ b/setup.py
@@ -52,7 +52,7 @@ console_scripts = [
 ]
 
 setup(name="mediagrains",
-      version="2.15.0",
+      version="2.15.1",
       python_requires='>=3.6.0',
       description="Simple utility for grain-based media",
       url='https://github.com/bbc/rd-apmm-python-lib-mediagrains',


### PR DESCRIPTION
Use self._next_pos in seek and tell if self._pos has not yet been aligned. Also, fix setting self._pos when aligning because self._next_pos is not updated after each read.

Pivotal: https://www.pivotaltracker.com/story/show/176206522