### PR TITLE
Support partial reads from asyncio.StreamReader wrapper

### DIFF
--- a/mediagrains/utils/asyncbinaryio.py
+++ b/mediagrains/utils/asyncbinaryio.py
@@ -336,7 +336,13 @@ class OpenAsyncStreamWrapper(OpenAsyncBinaryIO):
         if self.reader is None or self.reader.at_eof():
             return bytes()
         else:
-            return await self.reader.read(s)
+            if s < 0:
+                return await self.reader.read(s)
+            else:
+                try:
+                    return await self.reader.readexactly(s)
+                except asyncio.IncompleteReadError as e:
+                    return e.partial
 
     async def _align_pos(self):
         if self._next_pos > self._pos:

--- a/setup.py
+++ b/setup.py
@@ -52,7 +52,7 @@ console_scripts = [
 ]
 
 setup(name="mediagrains",
-      version="2.16.0",
+      version="2.16.1",
       python_requires='>=3.6.0',
       description="Simple utility for grain-based media",
       url='https://github.com/bbc/rd-apmm-python-lib-mediagrains',


### PR DESCRIPTION
Partial reads caused the GSF decoder to fail when reading from a asyncio.StreamReader source.

Found that the StreamReader.read(s) would sometimes return less than s in some web services, e.g. OpenStack S3 presigned URL endpoints. Using StreamReader.readexactly(s) instead to avoid that behaviour.

Tested using a presigned segment URL generated using Squirrel using S3-compatible storage on OpenStack LON1.

Pivotal job https://www.pivotaltracker.com/story/show/178690938