### PR TITLE
Fixed gsf wrappers from setting duration to 1/25s automatically

### DIFF
--- a/mediagrains/tools/wrap_in_gsf.py
+++ b/mediagrains/tools/wrap_in_gsf.py
@@ -94,17 +94,19 @@ def wrap_video_in_gsf():
     flow_id = args.flow_id if args.flow_id else uuid.uuid4()
     source_id = args.source_id if args.source_id else uuid.uuid4()
 
+    duration = 1/args.rate
+
     if args.format in [CogFrameFormat.H264, CogFrameFormat.AVCI]:
         template_grain = CodedVideoGrain(
             flow_id=flow_id, source_id=source_id, origin_timestamp=args.start_ts, rate=args.rate,
-            origin_width=width, origin_height=height, coded_width=0, coded_height=0,
+            duration=duration, origin_width=width, origin_height=height, coded_width=0, coded_height=0,
             cog_frame_format=args.format
         )
         Wrapper = H264GrainWrapper
     else:
         template_grain = VideoGrain(
             flow_id=flow_id, source_id=source_id, origin_timestamp=args.start_ts, rate=args.rate,
-            width=width, height=height, cog_frame_format=args.format
+            duration=duration, width=width, height=height, cog_frame_format=args.format
         )
         Wrapper = GrainWrapper
 
@@ -145,9 +147,12 @@ def wrap_audio_in_gsf():
     source_id = args.source_id if args.source_id else uuid.uuid4()
 
     if args.format == CogAudioFormat.AAC:
+        duration = fractions.Fraction(args.samples_per_grain, args.sample_rate)
+
         template_grain = CodedAudioGrain(
             flow_id=flow_id, source_id=source_id, origin_timestamp=args.start_ts, sample_rate=args.sample_rate,
-            channels=args.channels, samples=args.samples_per_grain, cog_audio_format=args.format
+            duration=duration, channels=args.channels, samples=args.samples_per_grain, cog_audio_format=args.format,
+            rate=fractions.Fraction(0, 1)
         )
         Wrapper = ADTSAACGrainWrapper
 
@@ -164,11 +169,12 @@ def wrap_audio_in_gsf():
         if sample_rate is None:
             sample_rate = 48000
 
-        grain_rate = fractions.Fraction(sample_rate, samples_per_grain)
+        duration = fractions.Fraction(samples_per_grain, sample_rate)
 
         template_grain = AudioGrain(
             flow_id=flow_id, source_id=source_id, origin_timestamp=args.start_ts, sample_rate=sample_rate,
-            rate=grain_rate, channels=channels, samples=samples_per_grain, cog_audio_format=args.format
+            duration=duration, channels=channels, samples=samples_per_grain, cog_audio_format=args.format,
+            rate=fractions.Fraction(0, 1)
         )
         Wrapper = GrainWrapper
 


### PR DESCRIPTION
# Details
The wrap_* functions set by default the duration of a grain to 1/25s, regardless of the rate of the grain. For most ordinary AV content, duration=1/rate and this was not happening when the rate was not 25(s^(-1)). This PR fixes the issue.

# Pivotal Story
Story URL: https://www.pivotaltracker.com/story/show/180426101

# Related PRs
_Where appropriate. Indicate order to be merged._

# Links to external test runs/working deployment
_Where appropriate, if separate to default CI run_

# Submitter PR Checks
_(tick as appropriate)_

- [x] Added bbc/rd-apmm-cloudfit team as a reviewer
- [x] PR completes task/fixes bug
- [x] Tests exercise code appropriately
- [x] New features and API breaks are flagged in commit messages using magic strings
- [ ] Repo maintainer is notified that a release is required
- [ ] Documentation updated (README, Confluence, Docstrings, API spec, Engineering Guide, etc.)
- [ ] Downstream repos have been checked for potential breaks & fixed as needed
- [ ] APIs/UIs/CLIs updated as required
- [x] PR added to Pivotal story
- [ ] Follow-up stories added to Pivotal
- [x] Any temporary code/configuration removed (e.g. test deployment environment, temporary commontooling branch)
- [x] Any pins against pre-releases have been removed

# Reviewer PR Checks
_(tick as appropriate)_

- [ ] PR completes task/fixes bug
- [ ] Tests exercise code appropriately
- [ ] Design makes sense, and fits with our current code base
- [ ] Code is easy to follow
- [ ] PR size is sensible
- [ ] Commit history is sensible and tidy

# Info on Cloudfit PRs
- The checks above are guidelines. They don't all have to be ticked, but they should all have been considered.
- For more details on how to asses PRs, see: https://github.com/bbc/rd-apmm-docs-ways-of-working/blob/master/workflow/PRChecklist.md
