### PR TITLE
Fix typing

### DIFF
--- a/mediagrains/numpy/audiograin.py
+++ b/mediagrains/numpy/audiograin.py
@@ -169,7 +169,7 @@ class AUDIOGRAIN (bytesgrain.AUDIOGRAIN):
             self.channel_data = []
         else:
             self._data_fetcher_coroutine = None
-            self._data = np.frombuffer(cast(GrainDataType, value), dtype=_dtype_from_cogaudioformat(self.format))
+            self._data = np.frombuffer(cast(bytes, value), dtype=_dtype_from_cogaudioformat(self.format))
             self.channel_data = _channel_arrays_for_data_and_type(
                 self._data, self.format, self.samples, self.channels
             )

--- a/mediagrains/numpy/videograin.py
+++ b/mediagrains/numpy/videograin.py
@@ -281,7 +281,7 @@ class VIDEOGRAIN (bytesgrain.VIDEOGRAIN):
             self.component_data = ComponentDataList([])
         else:
             self._data_fetcher_coroutine = None
-            self._data = np.frombuffer(cast(GrainDataType, value), dtype=_dtype_from_cogframeformat(self.format))
+            self._data = np.frombuffer(cast(bytes, value), dtype=_dtype_from_cogframeformat(self.format))
             self.component_data = ComponentDataList(
                 _component_arrays_for_data_and_type(self._data, self.format, self.components),
                 arrangement=_component_arrangement_from_format(self.format))


### PR DESCRIPTION
# Details
Fixes build failures on typing. Numpy has [updated](https://github.com/numpy/numpy/issues/20472) it's type annotations on the `frombuffer` function. This broke our type checking as it doesn't include `SupportsBytes` which is in the `union` we previously cast to. The [comment](https://github.com/numpy/numpy/blob/984a1ac8c911fa0130a6801a897642dd850796e6/numpy/__init__.pyi#L1398) against the type definition seems to imply that they know the type def isn't exhaustive and that this is due to a limitation of the C API + typing. This PR casts to `bytes` instead which is suitable for this case.

# Pivotal Story
Story URL:

# Related PRs
_Where appropriate. Indicate order to be merged._

# Links to external test runs/working deployment
_Where appropriate, if separate to default CI run_

# Submitter PR Checks
_(tick as appropriate)_

- [ ] Added bbc/rd-apmm-cloudfit team as a reviewer
- [ ] PR completes task/fixes bug
- [ ] Tests exercise code appropriately
- [ ] New features and API breaks are flagged in commit messages using magic strings
- [ ] Repo maintainer is notified that a release is required
- [ ] Documentation updated (README, Confluence, Docstrings, API spec, Engineering Guide, etc.)
- [ ] Downstream repos have been checked for potential breaks & fixed as needed
- [ ] APIs/UIs/CLIs updated as required
- [ ] PR added to Pivotal story
- [ ] Follow-up stories added to Pivotal
- [ ] Any temporary code/configuration removed (e.g. test deployment environment, temporary commontooling branch)
- [ ] Any pins against pre-releases have been removed

# Reviewer PR Checks
_(tick as appropriate)_

- [ ] PR completes task/fixes bug
- [ ] Tests exercise code appropriately
- [ ] Design makes sense, and fits with our current code base
- [ ] Code is easy to follow
- [ ] PR size is sensible
- [ ] Commit history is sensible and tidy

# Info on Cloudfit PRs
- The checks above are guidelines. They don't all have to be ticked, but they should all have been considered.
- For more details on how to asses PRs, see: https://github.com/bbc/rd-apmm-docs-ways-of-working/blob/master/workflow/PRChecklist.md
