### PR TITLE
Fix grain duration handling, typos

### DIFF
--- a/mediagrains/tools/wrap_in_gsf.py
+++ b/mediagrains/tools/wrap_in_gsf.py
@@ -98,14 +98,14 @@ def wrap_video_in_gsf():
 
     if args.format in [CogFrameFormat.H264, CogFrameFormat.AVCI]:
         template_grain = CodedVideoGrain(
-            flow_id=flow_id, source_id=source_id, origin_timestamp=args.start_ts, rate=args.rate,
+            flow_id=flow_id, src_id=source_id, origin_timestamp=args.start_ts, rate=args.rate,
             duration=duration, origin_width=width, origin_height=height, coded_width=0, coded_height=0,
             cog_frame_format=args.format
         )
         Wrapper = H264GrainWrapper
     else:
         template_grain = VideoGrain(
-            flow_id=flow_id, source_id=source_id, origin_timestamp=args.start_ts, rate=args.rate,
+            flow_id=flow_id, src_id=source_id, origin_timestamp=args.start_ts, rate=args.rate,
             duration=duration, width=width, height=height, cog_frame_format=args.format
         )
         Wrapper = GrainWrapper
@@ -150,7 +150,7 @@ def wrap_audio_in_gsf():
         duration = fractions.Fraction(args.samples_per_grain, args.sample_rate)
 
         template_grain = CodedAudioGrain(
-            flow_id=flow_id, source_id=source_id, origin_timestamp=args.start_ts, sample_rate=args.sample_rate,
+            flow_id=flow_id, src_id=source_id, origin_timestamp=args.start_ts, sample_rate=args.sample_rate,
             duration=duration, channels=args.channels, samples=args.samples_per_grain, cog_audio_format=args.format,
             rate=fractions.Fraction(0, 1)
         )
@@ -172,7 +172,7 @@ def wrap_audio_in_gsf():
         duration = fractions.Fraction(samples_per_grain, sample_rate)
 
         template_grain = AudioGrain(
-            flow_id=flow_id, source_id=source_id, origin_timestamp=args.start_ts, sample_rate=sample_rate,
+            flow_id=flow_id, src_id=source_id, origin_timestamp=args.start_ts, sample_rate=sample_rate,
             duration=duration, channels=channels, samples=samples_per_grain, cog_audio_format=args.format,
             rate=fractions.Fraction(0, 1)
         )

--- a/mediagrains/tools/wrap_in_gsf.py
+++ b/mediagrains/tools/wrap_in_gsf.py
@@ -94,18 +94,19 @@ def wrap_video_in_gsf():
     flow_id = args.flow_id if args.flow_id else uuid.uuid4()
     source_id = args.source_id if args.source_id else uuid.uuid4()
 
-    duration = 1/args.rate
+    rate_fraction = fractions.Fraction(args.rate)
+    duration = 1/rate_fraction
 
     if args.format in [CogFrameFormat.H264, CogFrameFormat.AVCI]:
         template_grain = CodedVideoGrain(
-            flow_id=flow_id, src_id=source_id, origin_timestamp=args.start_ts, rate=args.rate,
+            flow_id=flow_id, src_id=source_id, origin_timestamp=args.start_ts, rate=rate_fraction,
             duration=duration, origin_width=width, origin_height=height, coded_width=0, coded_height=0,
             cog_frame_format=args.format
         )
         Wrapper = H264GrainWrapper
     else:
         template_grain = VideoGrain(
-            flow_id=flow_id, src_id=source_id, origin_timestamp=args.start_ts, rate=args.rate,
+            flow_id=flow_id, src_id=source_id, origin_timestamp=args.start_ts, rate=rate_fraction,
             duration=duration, width=width, height=height, cog_frame_format=args.format
         )
         Wrapper = GrainWrapper


### PR DESCRIPTION
# Details
Fixes a bug where Grain duration always comes out as zero in `wrap_video_in_gsf`, by converting to a Fraction before inverting.

Also fixes a typo in the tool's constructing of Grains spotted while testing (as a result this will want to go in the same release as #99 @j616 )

# Pivotal Story
Story URL: https://www.pivotaltracker.com/story/show/181540104

# Related PRs
N/A

# Links to external test runs/working deployment
Tested locally by running the following command against this version, and confirming the duration shown was 1/25sec, rather than 0/1 (as happens on current main)
```
ffmpeg -i amazing-machines-redux-hd-30s.mp4 -f rawvideo -t 10 - | wrap_video_in_gsf --flow-id 19e31398-cf85-42e3-b3f5-d02dba35c0a1 --format U8_420 - sample.gsf
gsf_probe sample.gsf
```

# Submitter PR Checks
_(tick as appropriate)_

- [X] Added bbc/rd-apmm-cloudfit team as a reviewer
- [X] PR completes task/fixes bug
- [ ] Tests exercise code appropriately
- [X] New features and API breaks are flagged in commit messages using magic strings
- [X] Repo maintainer is notified that a release is required
- [ ] Documentation updated (README, Confluence, Docstrings, API spec, Engineering Guide, etc.)
- [ ] Downstream repos have been checked for potential breaks & fixed as needed
- [ ] APIs/UIs/CLIs updated as required
- [X] PR added to Pivotal story
- [ ] Follow-up stories added to Pivotal
- [ ] Any temporary code/configuration removed (e.g. test deployment environment, temporary commontooling branch)
- [ ] Any pins against pre-releases have been removed

# Reviewer PR Checks
_(tick as appropriate)_

- [ ] PR completes task/fixes bug
- [ ] Tests exercise code appropriately
- [ ] Design makes sense, and fits with our current code base
- [ ] Code is easy to follow
- [ ] PR size is sensible
- [ ] Commit history is sensible and tidy

# Info on Cloudfit PRs
- The checks above are guidelines. They don't all have to be ticked, but they should all have been considered.
- For more details on how to asses PRs, see: https://github.com/bbc/rd-apmm-docs-ways-of-working/blob/master/workflow/PRChecklist.md
