### PR TITLE
Updated CodedVideoGrain to support aspect ratio

### DIFF
--- a/mediagrains/grains/CodedVideoGrain.py
+++ b/mediagrains/grains/CodedVideoGrain.py
@@ -13,7 +13,9 @@ from uuid import UUID
 from mediatimestamp.immutable import Timestamp, SupportsMediaTimestamp, mediatimestamp
 from ..typing import (
     CodedVideoGrainMetadataDict,
-    GrainDataParameterType)
+    FractionDict,
+    GrainDataParameterType,
+    RationalTypes)
 
 from ..cogenums import CogFrameFormat, CogFrameLayout
 from .Grain import Grain
@@ -293,6 +295,38 @@ unit_offsets
     @temporal_offset.setter
     def temporal_offset(self, value: int) -> None:
         self.meta['grain']['cog_coded_frame']['temporal_offset'] = value
+
+    @property
+    def source_aspect_ratio(self) -> Optional[Fraction]:
+        if 'source_aspect_ratio' in self.meta['grain']['cog_coded_frame']:
+            return Fraction(cast(FractionDict,
+                                 self.meta['grain']['cog_coded_frame']['source_aspect_ratio'])['numerator'],
+                            cast(FractionDict,
+                                 self.meta['grain']['cog_coded_frame']['source_aspect_ratio'])['denominator'])
+        else:
+            return None
+
+    @source_aspect_ratio.setter
+    def source_aspect_ratio(self, value: RationalTypes) -> None:
+        value = Fraction(value)
+        self.meta['grain']['cog_coded_frame']['source_aspect_ratio'] = {'numerator': value.numerator,
+                                                                        'denominator': value.denominator}
+
+    @property
+    def pixel_aspect_ratio(self) -> Optional[Fraction]:
+        if 'pixel_aspect_ratio' in self.meta['grain']['cog_coded_frame']:
+            return Fraction(cast(FractionDict,
+                                 self.meta['grain']['cog_coded_frame']['pixel_aspect_ratio'])['numerator'],
+                            cast(FractionDict,
+                                 self.meta['grain']['cog_coded_frame']['pixel_aspect_ratio'])['denominator'])
+        else:
+            return None
+
+    @pixel_aspect_ratio.setter
+    def pixel_aspect_ratio(self, value: RationalTypes) -> None:
+        value = Fraction(value)
+        self.meta['grain']['cog_coded_frame']['pixel_aspect_ratio'] = {'numerator': value.numerator,
+                                                                       'denominator': value.denominator}
 
     class UNITOFFSETS(MutableSequence):
         def __init__(self, parent: "CodedVideoGrain"):

--- a/mediagrains/typing.py
+++ b/mediagrains/typing.py
@@ -179,6 +179,8 @@ class _GrainGrainMetadataDict_cogcodedframe_MANDATORY (TypedDict):
 class _GrainGrainMetadataDict_cogcodedframe (_GrainGrainMetadataDict_cogcodedframe_MANDATORY, total=False):
     unit_offsets: Sequence[int]
     length: int
+    source_aspect_ratio: Union[FractionDict, Fraction, RationalTypes]
+    pixel_aspect_ratio: Union[FractionDict, Fraction, RationalTypes]
 
 
 class CodedVideoGrainGrainMetadataDict (_GrainGrainMetadataDict_common):


### PR DESCRIPTION
# Details
Added support for aspect ratio to CodedVideoGrain to stop mediamodels whinging. Have tested against mediamodels (mypy & tests), media-api (tests).

# Pivotal Story
Story URL: N/A

# Related PRs
_Where appropriate. Indicate order to be merged._

# Links to external test runs/working deployment
_Where appropriate, if separate to default CI run_

# Submitter PR Checks
_(tick as appropriate)_

- [x] Added bbc/rd-apmm-cloudfit team as a reviewer
- [x] PR completes task/fixes bug
- [x] Tests exercise code appropriately
- [x] New features and API breaks are flagged in commit messages using magic strings
- [ ] Repo maintainer is notified that a release is required
- [ ] Documentation updated (README, Confluence, Docstrings, API spec, Engineering Guide, etc.)
- [x] Downstream repos have been checked for potential breaks & fixed as needed
- [ ] APIs/UIs/CLIs updated as required
- [ ] PR added to Pivotal story
- [ ] Follow-up stories added to Pivotal
- [ ] Any temporary code/configuration removed (e.g. test deployment environment, temporary commontooling branch)
- [ ] Any pins against pre-releases have been removed

# Reviewer PR Checks
_(tick as appropriate)_

- [ ] PR completes task/fixes bug
- [ ] Tests exercise code appropriately
- [ ] Design makes sense, and fits with our current code base
- [ ] Code is easy to follow
- [ ] PR size is sensible
- [ ] Commit history is sensible and tidy

# Info on Cloudfit PRs
- The checks above are guidelines. They don't all have to be ticked, but they should all have been considered.
- For more details on how to asses PRs, see: https://github.com/bbc/rd-apmm-docs-ways-of-working/blob/master/workflow/PRChecklist.md
