### PR TITLE
Add tools as Dockerfile layers and allow containers to be built using make

### DIFF
--- a/Dockerfile_multi.j2
+++ b/Dockerfile_multi.j2
@@ -29,3 +29,18 @@ CMD ["discover", "tests", "-v"]
 
 {{ macros.docs(modname) }}
 CMD ["--html", "--force", "--skip-errors", "--output-dir", ".", "{{ modname }}"]
+
+FROM {{ modname + ":" + "${BUILD_TAG}" }} AS tools_base
+WORKDIR /data
+
+FROM tools_base as extract_gsf_essence
+ENTRYPOINT ["extract_gsf_essence"]
+
+FROM tools_base AS gsf_probe
+ENTRYPOINT ["gsf_probe"]
+
+FROM tools_base AS wrap_audio_in_gsf
+ENTRYPOINT ["wrap_audio_in_gsf"]
+
+FROM tools_base AS wrap_video_in_gsf
+ENTRYPOINT ["wrap_video_in_gsf"]

--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,39 @@
 USE_VERSION_FILE:=TRUE
+MS_DOCKER_PUSH:=TRUE
 
 include ./static-commontooling/make/lib_static_commontooling.mk
 include ./static-commontooling/make/standalone.mk
 include ./static-commontooling/make/pythonic.mk
 include ./static-commontooling/make/docker.mk
+
+all: tools-help
+
+tools-help:
+	@echo "make tools                       - Build the docker containers for all tools"
+	@echo "make tool-gsf_probe              - Build the docker container for the gsf_probe tool"
+	@echo "make tool-extract_gsf_essence    - Build the docker container for the extract_gsf_essence tool"
+	@echo "make tool-wrap_audio_in_gsf      - Build the docker container for the wrap_audio_in_gsf tool"
+	@echo "make tool-wrap_video_in_gsf      - Build the docker container for the wrap_video_in_gsf tool"
+	@echo "make run-cmd-<tool name>         - Output the docker command required to make use of a tool container"
+
+tools: tool-gsf_probe tool-extract_gsf_essence tool-wrap_audio_in_gsf tool-wrap_video_in_gsf
+
+tool-gsf_probe: ms_docker-build-gsf_probe
+
+tool-extract_gsf_essence: ms_docker-build-extract_gsf_essence
+
+tool-wrap_audio_in_gsf: ms_docker-build-wrap_audio_in_gsf
+
+tool-wrap_video_in_gsf: ms_docker-build-wrap_video_in_gsf
+
+run-cmd-%: ms_docker-build-%
+	@echo docker run --rm -it -v $(shell pwd):/data ${MODNAME}_$*:${BUILD_TAG}
+
+ifeq "${enable_push}" "TRUE"
+push: ms_docker-push-gsf_probe ms_docker-push-extract_gsf_essence ms_docker-push-wrap_audio_in_gsf ms_docker-push-wrap_video_in_gsf 
+
+push-%: ms_docker-push-%
+	@echo Push successful
+endif
+
+.PHONY: tools tool-gsf_probe tool-extract_gsf_essence tool-wrap_audio_in_gsf tool-wrap_video_in_gsf run-cmd-% push-%

--- a/README.md
+++ b/README.md
@@ -220,6 +220,26 @@ gsf_probe output_audio.gsf
 extract_gsf_essence output_audio.gsf - | ffplay -f s16le -ac 2 -ar 44100 pipe:0
 ```
 
+The tools have been packaged into docker images for convenience. Images for all the tools can be built using:
+```bash
+make tools
+```
+
+Or individual tool images can be built using one of the following:
+```bash
+make tool-gsf_probe
+make tool-extract_gsf_essence
+make tool-tool-wrap_audio_in_gsf
+make tool-tool-wrap_video_in_gsf
+```
+
+You can make use of the tools images with the following command, replacing the source data directory, image name and build tag as required:
+```bash
+$(make -s run-cmd-extract_gsf_essence) <ARGS>
+```
+
+Running the command without ARGS will provide help
+
 ## Development
 ### Commontooling
 


### PR DESCRIPTION
# Details
Adds makefile targets for each of the tools containers. This will mean the docker images no longer need to live in the docker-images repo.

# Pivotal Story
Story URL: https://www.pivotaltracker.com/story/show/181173008

# Related PRs
[_Where appropriate. Indicate order to be merged._]
https://github.com/bbc/rd-cloudfit-docker-images/pull/43

# Links to external test runs/working deployment
_Where appropriate, if separate to default CI run_

# Submitter PR Checks
_(tick as appropriate)_

- [x] Added bbc/rd-apmm-cloudfit team as a reviewer
- [x] PR completes task/fixes bug
- [ ] Tests exercise code appropriately
- [ ] New features and API breaks are flagged in commit messages using magic strings
- [ ] Repo maintainer is notified that a release is required
- [ ] Documentation updated (README, Confluence, Docstrings, API spec, Engineering Guide, etc.)
- [x] Downstream repos have been checked for potential breaks & fixed as needed
- [ ] APIs/UIs/CLIs updated as required
- [ ] PR added to Pivotal story
- [ ] Follow-up stories added to Pivotal
- [ ] Any temporary code/configuration removed (e.g. test deployment environment, temporary commontooling branch)
- [ ] Any pins against pre-releases have been removed

# Reviewer PR Checks
_(tick as appropriate)_

- [ ] PR completes task/fixes bug
- [ ] Tests exercise code appropriately
- [ ] Design makes sense, and fits with our current code base
- [ ] Code is easy to follow
- [ ] PR size is sensible
- [ ] Commit history is sensible and tidy

# Info on Cloudfit PRs
- The checks above are guidelines. They don't all have to be ticked, but they should all have been considered.
- For more details on how to asses PRs, see: https://github.com/bbc/rd-apmm-docs-ways-of-working/blob/master/workflow/PRChecklist.md
