### PR TITLE
Grains can now be instantiated without arguments.

### DIFF
--- a/mediagrains/grains/AudioGrain.py
+++ b/mediagrains/grains/AudioGrain.py
@@ -115,14 +115,9 @@ sample_rate
                  sample_rate: int = 48000):
 
         if meta is None:
-            if src_id is None:
-                raise AttributeError("src_id is None. Meta is None so src_id must not be None.")
-            if flow_id is None:
-                raise AttributeError("flow_id is None. Meta is None so flow_id must not be None.")
-
-            if not isinstance(src_id, UUID):
+            if not isinstance(src_id, UUID) and src_id is not None:
                 raise AttributeError(f"src_id: Seen type {type(src_id)}, expected UUID.")
-            if not isinstance(flow_id, UUID):
+            if not isinstance(flow_id, UUID) and flow_id is not None:
                 raise AttributeError(f"flow_id: Seen type {type(flow_id)}, expected UUID.")
 
             if creation_timestamp is None:

--- a/mediagrains/grains/CodedAudioGrain.py
+++ b/mediagrains/grains/CodedAudioGrain.py
@@ -116,14 +116,9 @@ remainder
                 length = 0
 
         if meta is None:
-            if src_id is None:
-                raise AttributeError("src_id is None. Meta is None so src_id must not be None.")
-            if flow_id is None:
-                raise AttributeError("flow_id is None. Meta is None so flow_id must not be None.")
-
-            if not isinstance(src_id, UUID):
+            if not isinstance(src_id, UUID) and src_id is not None:
                 raise AttributeError(f"src_id: Seen type {type(src_id)}, expected UUID.")
-            if not isinstance(flow_id, UUID):
+            if not isinstance(flow_id, UUID) and flow_id is not None:
                 raise AttributeError(f"flow_id: Seen type {type(flow_id)}, expected UUID.")
 
             creation_timestamp = Timestamp.get_time() if not creation_timestamp else creation_timestamp

--- a/mediagrains/grains/CodedVideoGrain.py
+++ b/mediagrains/grains/CodedVideoGrain.py
@@ -136,14 +136,9 @@ unit_offsets
                 length = 0
 
         if meta is None:
-            if src_id is None:
-                raise AttributeError("src_id is None. Meta is None so src_id must not be None.")
-            if flow_id is None:
-                raise AttributeError("flow_id is None. Meta is None so flow_id must not be None.")
-
-            if not isinstance(src_id, UUID):
+            if not isinstance(src_id, UUID) and src_id is not None:
                 raise AttributeError(f"src_id: Seen type {type(src_id)}, expected UUID.")
-            if not isinstance(flow_id, UUID):
+            if not isinstance(flow_id, UUID) and flow_id is not None:
                 raise AttributeError(f"flow_id: Seen type {type(flow_id)}, expected UUID.")
 
             if creation_timestamp is None:

--- a/mediagrains/grains/EventGrain.py
+++ b/mediagrains/grains/EventGrain.py
@@ -114,14 +114,9 @@ append(path, pre=None, post=None)
                  topic: str = ''):
 
         if meta is None:
-            if src_id is None:
-                raise AttributeError("src_id is None. Meta is None so src_id must not be None.")
-            if flow_id is None:
-                raise AttributeError("flow_id is None. Meta is None so flow_id must not be None.")
-
-            if not isinstance(src_id, UUID):
+            if not isinstance(src_id, UUID) and src_id is not None:
                 raise AttributeError(f"src_id: Seen type {type(src_id)}, expected UUID.")
-            if not isinstance(flow_id, UUID):
+            if not isinstance(flow_id, UUID) and flow_id is not None:
                 raise AttributeError(f"flow_id: Seen type {type(flow_id)}, expected UUID.")
 
             cts = creation_timestamp

--- a/mediagrains/grains/VideoGrain.py
+++ b/mediagrains/grains/VideoGrain.py
@@ -260,14 +260,9 @@ length
                  cog_frame_layout: CogFrameLayout = CogFrameLayout.UNKNOWN):
 
         if meta is None:
-            if src_id is None:
-                raise AttributeError("src_id is None. Meta is None so src_id must not be None.")
-            if flow_id is None:
-                raise AttributeError("flow_id is None. Meta is None so flow_id must not be None.")
-
-            if not isinstance(src_id, UUID):
+            if not isinstance(src_id, UUID) and src_id is not None:
                 raise AttributeError(f"src_id: Seen type {type(src_id)}, expected UUID.")
-            if not isinstance(flow_id, UUID):
+            if not isinstance(flow_id, UUID) and flow_id is not None:
                 raise AttributeError(f"flow_id: Seen type {type(flow_id)}, expected UUID.")
 
             if creation_timestamp is None:

--- a/mediagrains/numpy/convert.py
+++ b/mediagrains/numpy/convert.py
@@ -152,11 +152,11 @@ def _convert_rgb_to_yuv444(grain_in: VideoGrain, grain_out: VideoGrain) -> None:
                  grain_in.component_data.G,
                  grain_in.component_data.B)
 
-    np.clip((R*0.2126 + G*0.7152 + B*0.0722), 0, 1 << bd, out=grain_out.component_data.Y, casting="unsafe")
+    np.clip((R*0.2126 + G*0.7152 + B*0.0722), 0, 1 << bd, out=grain_out.component_data.Y)
     np.clip((R*-0.114572 - G*0.385428 + B*0.5 + (1 << (bd - 1))),
-            0, 1 << bd, out=grain_out.component_data.U, casting="unsafe")
+            0, 1 << bd, out=grain_out.component_data.U)
     np.clip((R*0.5 - G*0.454153 - B*0.045847 + (1 << (bd - 1))),
-            0, 1 << bd, out=grain_out.component_data.V, casting="unsafe")
+            0, 1 << bd, out=grain_out.component_data.V)
 
 
 def _convert_yuv444_to_rgb(grain_in: VideoGrain, grain_out: VideoGrain) -> None:
@@ -165,9 +165,9 @@ def _convert_yuv444_to_rgb(grain_in: VideoGrain, grain_out: VideoGrain) -> None:
                  grain_in.component_data.U.astype(np.dtype(np.double)) - (1 << (bd - 1)),
                  grain_in.component_data.V.astype(np.dtype(np.double)) - (1 << (bd - 1)))
 
-    np.clip((Y + V*1.5748), 0, 1 << bd, out=grain_out.component_data.R, casting="unsafe")
-    np.clip((Y - U*0.187324 - V*0.468124), 0, 1 << bd, out=grain_out.component_data.G, casting="unsafe")
-    np.clip((Y + U*1.8556), 0, 1 << bd, out=grain_out.component_data.B, casting="unsafe")
+    np.clip((Y + V*1.5748), 0, 1 << bd, out=grain_out.component_data.R)
+    np.clip((Y - U*0.187324 - V*0.468124), 0, 1 << bd, out=grain_out.component_data.G)
+    np.clip((Y + U*1.8556), 0, 1 << bd, out=grain_out.component_data.B)
 
 
 def _convert_v210_to_yuv422_10bit(grain_in: VideoGrain, grain_out: VideoGrain) -> None:

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,4 +1,5 @@
 [mypy]
+plugins = numpy.typing.mypy_plugin
 
 [mypy-bitstring.*]
 ignore_missing_imports = True

--- a/setup.py
+++ b/setup.py
@@ -57,7 +57,7 @@ packages_required = [
     "mediajson >=2.0.0",
     "mediatimestamp >=2.1.0",
     "frozendict >= 1.2",
-    'numpy >= 1.17.2',
+    'numpy >= 1.23.0',
     'deprecated >= 1.2.6',
     "bitstring"
 ]

--- a/tests/test_grain.py
+++ b/tests/test_grain.py
@@ -647,8 +647,23 @@ class TestGrain (IsolatedAsyncioTestCase):
             Grain([], 0x44)
 
     def test_video_grain_fails_with_no_metadata(self):
-        with self.assertRaises(AttributeError):
-            VideoGrain(None)
+        with mock.patch.object(Timestamp, "get_time", return_value=cts):
+            grain = VideoGrain()
+
+        self.assertEqual(grain.origin_timestamp, cts)
+        self.assertEqual(grain.sync_timestamp, cts)
+        self.assertEqual(grain.creation_timestamp, cts)
+        self.assertEqual(grain.grain_type, "video")
+        self.assertEqual(grain.rate, Fraction(25, 1))
+        self.assertEqual(grain.duration, Fraction(1, 25))
+        self.assertEqual(grain.timelabels, [])
+        self.assertEqual(grain.format, CogFrameFormat.UNKNOWN)
+        self.assertEqual(grain.width, 1920)
+        self.assertEqual(grain.height, 1080)
+        self.assertEqual(grain.layout, CogFrameLayout.UNKNOWN)
+        self.assertEqual(grain.extension, 0)
+        self.assertIsNone(grain.source_aspect_ratio)
+        self.assertIsNone(grain.pixel_aspect_ratio)
 
     def test_video_grain_create_with_ots_and_no_sts(self):
         with mock.patch.object(Timestamp, "get_time", return_value=cts):
@@ -859,9 +874,18 @@ class TestGrain (IsolatedAsyncioTestCase):
             repr(grain),
             "AudioGrain({!r},< binary data of length {} >)".format(grain.meta, len(grain.data)))
 
-    def test_audio_grain_create_fails_with_no_params(self):
-        with self.assertRaises(AttributeError):
-            AudioGrain(None)
+    def test_audio_grain_create_no_params(self):
+        with mock.patch.object(Timestamp, "get_time", return_value=cts):
+            grain = AudioGrain()
+
+        self.assertEqual(grain.creation_timestamp, cts)
+        self.assertEqual(grain.origin_timestamp, cts)
+        self.assertEqual(grain.sync_timestamp, cts)
+        self.assertEqual(grain.format, CogAudioFormat.INVALID)
+        self.assertEqual(grain.channels, 0)
+        self.assertEqual(grain.samples, 0)
+        self.assertEqual(grain.sample_rate, 48000)
+        self.assertEqual(grain.media_rate, Fraction(48000, 1))
 
     def test_audio_grain_create_all_formats(self):
         for (fmt, length) in [(CogAudioFormat.S16_PLANES,         1920*2*2),
@@ -1166,9 +1190,25 @@ class TestGrain (IsolatedAsyncioTestCase):
         self.assertEqual(grain.origin_timestamp, cts)
         self.assertEqual(grain.sync_timestamp, cts)
 
-    def test_coded_video_grain_create_fails_with_empty(self):
-        with self.assertRaises(AttributeError):
-            CodedVideoGrain(None)
+    def test_coded_video_grain_create_with_empty(self):
+        with mock.patch.object(Timestamp, "get_time", return_value=cts):
+            grain = CodedVideoGrain()
+
+        self.assertEqual(grain.grain_type, "coded_video")
+        self.assertEqual(grain.origin_timestamp, cts)
+        self.assertEqual(grain.sync_timestamp, cts)
+        self.assertEqual(grain.creation_timestamp, cts)
+        self.assertEqual(grain.rate, Fraction(25, 1))
+        self.assertEqual(grain.duration, Fraction(1, 25))
+        self.assertEqual(grain.timelabels, [])
+        self.assertEqual(grain.format, CogFrameFormat.UNKNOWN)
+        self.assertEqual(grain.origin_width, 1920)
+        self.assertEqual(grain.origin_height, 1080)
+        self.assertEqual(grain.coded_width, 1920)
+        self.assertEqual(grain.coded_height, 1080)
+        self.assertEqual(grain.length, 0)
+        self.assertEqual(grain.layout, CogFrameLayout.UNKNOWN)
+        self.assertEqual(grain.unit_offsets, [])
 
     def test_coded_video_grain_meta_is_json_serialisable(self):
         with mock.patch.object(Timestamp, "get_time", return_value=cts):
@@ -1434,9 +1474,23 @@ class TestGrain (IsolatedAsyncioTestCase):
         self.assertEqual(grain.length, len(data))
         self.assertEqual(grain.data, data)
 
-    def test_coded_audio_grain_raises_on_empty(self):
-        with self.assertRaises(AttributeError):
-            CodedAudioGrain(None)
+    def test_coded_audio_grain_creates_with_none(self):
+        with mock.patch.object(Timestamp, "get_time", return_value=cts):
+            grain = CodedAudioGrain()
+        self.assertEqual(grain.grain_type, "coded_audio")
+        self.assertEqual(grain.origin_timestamp, cts)
+        self.assertEqual(grain.sync_timestamp, cts)
+        self.assertEqual(grain.creation_timestamp, cts)
+        self.assertEqual(grain.rate, Fraction(25, 1))
+        self.assertEqual(grain.duration, Fraction(1, 25))
+        self.assertEqual(grain.timelabels, [])
+        self.assertEqual(grain.format, CogAudioFormat.INVALID)
+        self.assertEqual(grain.samples, 0)
+        self.assertEqual(grain.channels, 0)
+        self.assertEqual(grain.priming, 0)
+        self.assertEqual(grain.remainder, 0)
+        self.assertEqual(grain.sample_rate, 48000)
+        self.assertEqual(grain.length, 0)
 
     def test_codedaudiograin_meta_is_json_serialisable(self):
         with mock.patch.object(Timestamp, "get_time", return_value=cts):
@@ -1607,9 +1661,22 @@ class TestGrain (IsolatedAsyncioTestCase):
         self.assertEqual(grain.topic, "")
         self.assertEqual(grain.event_data, [])
 
-    def test_event_grain_create_fails_on_None(self):
-        with self.assertRaises(AttributeError):
-            EventGrain(None)
+    def test_event_grain_create_no_arguments(self):
+        with mock.patch.object(Timestamp, "get_time", return_value=cts):
+            grain = EventGrain()
+
+        self.assertEqual(grain.grain_type, "event")
+        self.assertEqual(grain.origin_timestamp, cts)
+        self.assertEqual(grain.final_origin_timestamp(), cts)
+        self.assertEqual(grain.origin_timerange(), TimeRange.from_single_timestamp(cts))
+        self.assertEqual(grain.sync_timestamp, cts)
+        self.assertEqual(grain.creation_timestamp, cts)
+        self.assertEqual(grain.rate, Fraction(25, 1))
+        self.assertEqual(grain.duration, Fraction(1, 25))
+        self.assertEqual(grain.timelabels, [])
+        self.assertEqual(grain.event_type, "")
+        self.assertEqual(grain.topic, "")
+        self.assertEqual(grain.event_data, [])
 
     def test_event_grain_create_from_meta_and_data(self):
         meta = {

--- a/tests/test_grain.py
+++ b/tests/test_grain.py
@@ -646,7 +646,7 @@ class TestGrain (IsolatedAsyncioTestCase):
         with self.assertRaises(AttributeError):
             Grain([], 0x44)
 
-    def test_video_grain_fails_with_no_metadata(self):
+    def test_video_grain_with_no_metadata(self):
         with mock.patch.object(Timestamp, "get_time", return_value=cts):
             grain = VideoGrain()
 

--- a/tests/test_grain_newcode.py
+++ b/tests/test_grain_newcode.py
@@ -647,9 +647,24 @@ class TestGrain (IsolatedAsyncioTestCase):
         with self.assertRaises(AttributeError):
             Grain(src_id=[], flow_id=0x44)
 
-    def test_video_grain_fails_with_no_metadata(self):
-        with self.assertRaises(AttributeError):
-            VideoGrain(None)
+    def test_video_grain_create_with_no_metadata(self):
+        with mock.patch.object(Timestamp, "get_time", return_value=cts):
+            grain = VideoGrain()
+
+        self.assertEqual(grain.origin_timestamp, cts)
+        self.assertEqual(grain.sync_timestamp, cts)
+        self.assertEqual(grain.creation_timestamp, cts)
+        self.assertEqual(grain.grain_type, "video")
+        self.assertEqual(grain.rate, Fraction(25, 1))
+        self.assertEqual(grain.duration, Fraction(1, 25))
+        self.assertEqual(grain.timelabels, [])
+        self.assertEqual(grain.format, CogFrameFormat.UNKNOWN)
+        self.assertEqual(grain.width, 1920)
+        self.assertEqual(grain.height, 1080)
+        self.assertEqual(grain.layout, CogFrameLayout.UNKNOWN)
+        self.assertEqual(grain.extension, 0)
+        self.assertIsNone(grain.source_aspect_ratio)
+        self.assertIsNone(grain.pixel_aspect_ratio)
 
     def test_video_grain_create_with_ots_and_no_sts(self):
         with mock.patch.object(Timestamp, "get_time", return_value=cts):
@@ -860,9 +875,18 @@ class TestGrain (IsolatedAsyncioTestCase):
             repr(grain),
             "AudioGrain({!r},< binary data of length {} >)".format(grain.meta, len(grain.data)))
 
-    def test_audio_grain_create_fails_with_no_params(self):
-        with self.assertRaises(AttributeError):
-            AudioGrain(None)
+    def test_audio_grain_create_with_no_params(self):
+        with mock.patch.object(Timestamp, "get_time", return_value=cts):
+            grain = AudioGrain()
+
+        self.assertEqual(grain.creation_timestamp, cts)
+        self.assertEqual(grain.origin_timestamp, cts)
+        self.assertEqual(grain.sync_timestamp, cts)
+        self.assertEqual(grain.format, CogAudioFormat.INVALID)
+        self.assertEqual(grain.channels, 0)
+        self.assertEqual(grain.samples, 0)
+        self.assertEqual(grain.sample_rate, 48000)
+        self.assertEqual(grain.media_rate, Fraction(48000, 1))
 
     def test_audio_grain_create_all_formats(self):
         for (fmt, length) in [(CogAudioFormat.S16_PLANES,         1920*2*2),
@@ -1167,9 +1191,25 @@ class TestGrain (IsolatedAsyncioTestCase):
         self.assertEqual(grain.origin_timestamp, cts)
         self.assertEqual(grain.sync_timestamp, cts)
 
-    def test_coded_video_grain_create_fails_with_empty(self):
-        with self.assertRaises(AttributeError):
-            CodedVideoGrain(None)
+    def test_coded_video_grain_create_empty(self):
+        with mock.patch.object(Timestamp, "get_time", return_value=cts):
+            grain = CodedVideoGrain()
+
+        self.assertEqual(grain.grain_type, "coded_video")
+        self.assertEqual(grain.origin_timestamp, cts)
+        self.assertEqual(grain.sync_timestamp, cts)
+        self.assertEqual(grain.creation_timestamp, cts)
+        self.assertEqual(grain.rate, Fraction(25, 1))
+        self.assertEqual(grain.duration, Fraction(1, 25))
+        self.assertEqual(grain.timelabels, [])
+        self.assertEqual(grain.format, CogFrameFormat.UNKNOWN)
+        self.assertEqual(grain.origin_width, 1920)
+        self.assertEqual(grain.origin_height, 1080)
+        self.assertEqual(grain.coded_width, 1920)
+        self.assertEqual(grain.coded_height, 1080)
+        self.assertEqual(grain.length, 0)
+        self.assertEqual(grain.layout, CogFrameLayout.UNKNOWN)
+        self.assertEqual(grain.unit_offsets, [])
 
     def test_coded_video_grain_meta_is_json_serialisable(self):
         with mock.patch.object(Timestamp, "get_time", return_value=cts):
@@ -1435,9 +1475,24 @@ class TestGrain (IsolatedAsyncioTestCase):
         self.assertEqual(grain.length, len(data))
         self.assertEqual(grain.data, data)
 
-    def test_coded_audio_grain_raises_on_empty(self):
-        with self.assertRaises(AttributeError):
-            CodedAudioGrain(None)
+    def test_coded_audio_grain_empty(self):
+        with mock.patch.object(Timestamp, "get_time", return_value=cts):
+            grain = CodedAudioGrain()
+
+        self.assertEqual(grain.grain_type, "coded_audio")
+        self.assertEqual(grain.origin_timestamp, cts)
+        self.assertEqual(grain.sync_timestamp, cts)
+        self.assertEqual(grain.creation_timestamp, cts)
+        self.assertEqual(grain.rate, Fraction(25, 1))
+        self.assertEqual(grain.duration, Fraction(1, 25))
+        self.assertEqual(grain.timelabels, [])
+        self.assertEqual(grain.format, CogAudioFormat.INVALID)
+        self.assertEqual(grain.samples, 0)
+        self.assertEqual(grain.channels, 0)
+        self.assertEqual(grain.priming, 0)
+        self.assertEqual(grain.remainder, 0)
+        self.assertEqual(grain.sample_rate, 48000)
+        self.assertEqual(grain.length, 0)
 
     def test_codedaudiograin_meta_is_json_serialisable(self):
         with mock.patch.object(Timestamp, "get_time", return_value=cts):
@@ -1608,9 +1663,22 @@ class TestGrain (IsolatedAsyncioTestCase):
         self.assertEqual(grain.topic, "")
         self.assertEqual(grain.event_data, [])
 
-    def test_event_grain_create_fails_on_None(self):
-        with self.assertRaises(AttributeError):
-            EventGrain(None)
+    def test_event_grain_create_no_arguments(self):
+        with mock.patch.object(Timestamp, "get_time", return_value=cts):
+            grain = EventGrain()
+
+        self.assertEqual(grain.grain_type, "event")
+        self.assertEqual(grain.origin_timestamp, cts)
+        self.assertEqual(grain.final_origin_timestamp(), cts)
+        self.assertEqual(grain.origin_timerange(), TimeRange.from_single_timestamp(cts))
+        self.assertEqual(grain.sync_timestamp, cts)
+        self.assertEqual(grain.creation_timestamp, cts)
+        self.assertEqual(grain.rate, Fraction(25, 1))
+        self.assertEqual(grain.duration, Fraction(1, 25))
+        self.assertEqual(grain.timelabels, [])
+        self.assertEqual(grain.event_type, "")
+        self.assertEqual(grain.topic, "")
+        self.assertEqual(grain.event_data, [])
 
     def test_event_grain_create_from_meta_and_data(self):
         meta = {


### PR DESCRIPTION
# Details
Grains can now be instantiated without arguments.

# Pivotal Story
Story URL: https://www.pivotaltracker.com/story/show/182178056

# Related PRs
_Where appropriate. Indicate order to be merged._

# Links to external test runs/working deployment
_Where appropriate, if separate to default CI run_

# Submitter PR Checks
_(tick as appropriate)_

- [x] Added bbc/rd-apmm-cloudfit team as a reviewer
- [x] PR completes task/fixes bug
- [x] Tests exercise code appropriately
- [x] New features and API breaks are flagged in commit messages using magic strings
- [ ] Repo maintainer is notified that a release is required
- [ ] Documentation updated (README, Confluence, Docstrings, API spec, Engineering Guide, etc.)
- [ ] Downstream repos have been checked for potential breaks & fixed as needed
- [ ] APIs/UIs/CLIs updated as required
- [ ] PR added to Pivotal story
- [ ] Follow-up stories added to Pivotal
- [ ] Any temporary code/configuration removed (e.g. test deployment environment, temporary commontooling branch)
- [ ] Any pins against pre-releases have been removed

# Reviewer PR Checks
_(tick as appropriate)_

- [ ] PR completes task/fixes bug
- [ ] Tests exercise code appropriately
- [ ] Design makes sense, and fits with our current code base
- [ ] Code is easy to follow
- [ ] PR size is sensible
- [ ] Commit history is sensible and tidy

# Info on Cloudfit PRs
- The checks above are guidelines. They don't all have to be ticked, but they should all have been considered.
- For more details on how to asses PRs, see: https://github.com/bbc/rd-apmm-docs-ways-of-working/blob/master/workflow/PRChecklist.md
