### PR TITLE
Fix linting failures

### DIFF
--- a/mediagrains/grains/Grain.py
+++ b/mediagrains/grains/Grain.py
@@ -136,7 +136,7 @@ def _stringify_timestamp_input(value: Union[SupportsMediaTimestamp, SupportsMedi
 
 # For use in 'new style' grain init. Can be removed once old style is excised.
 def new_attributes_for_grain_type(grain_type: str | GrainType):
-    return(attributes_for_grain_type(grain_type=grain_type, new=True))
+    return (attributes_for_grain_type(grain_type=grain_type, new=True))
 
 
 # As above, the 'new' parameter will give 'new style' grain init info. 'x if not new else' statements can be removed

--- a/mediagrains/numpy/numpy_grains/AudioGrain.py
+++ b/mediagrains/numpy/numpy_grains/AudioGrain.py
@@ -49,8 +49,8 @@ def _channel_arrays_for_data_and_type(data: Optional[np.ndarray],
                                       format: CogAudioFormat,
                                       samples: int,
                                       channels: int) -> List[np.ndarray]:
-    """This method returns a list of numpy array views which can be used to directly access the channels of the audio frame
-    without any need for conversion or copying. This is not possible for all formats.
+    """This method returns a list of numpy array views which can be used to directly access the channels of the audio
+    frame without any need for conversion or copying. This is not possible for all formats.
 
     24-bit samples are widened to 32-bit. Planar 24-bit samples held in the lower part of 32-bit are shifted to the
     upper part.

--- a/mediagrains/utils/adts_aac_grain_wrapper.py
+++ b/mediagrains/utils/adts_aac_grain_wrapper.py
@@ -39,7 +39,7 @@ class ADTSAACGrainWrapper(object):
                                source. origin_timestamp should be set.
         :param input_data: An object to read video data from
         """
-        assert(isinstance(template_grain, CODEDAUDIOGRAIN))
+        assert (isinstance(template_grain, CODEDAUDIOGRAIN))
         self.template_grain = copy.deepcopy(template_grain)  # make a copy as the template defaults will be updated
         self.input_data = input_data
 
@@ -86,8 +86,8 @@ class ADTSAACGrainWrapper(object):
 
         media_rate = self.template_grain.media_rate
         coded_frame_size = self.template_grain.samples
-        assert(media_rate is not None)
-        assert(coded_frame_size is not None)
+        assert (media_rate is not None)
+        assert (coded_frame_size is not None)
 
         norm_origin_ts = self.template_grain.origin_timestamp.normalise(media_rate.numerator, media_rate.denominator)
         grain_timerange = TimeRange.from_start(norm_origin_ts)

--- a/mediagrains/utils/h264_grain_wrapper.py
+++ b/mediagrains/utils/h264_grain_wrapper.py
@@ -42,7 +42,7 @@ class H264GrainWrapper(object):
                                source. origin_timestamp should be set.
         :param input_data: An object to read video data from
         """
-        assert(isinstance(template_grain, CodedVideoGrain))
+        assert (isinstance(template_grain, CodedVideoGrain))
         self.template_grain = copy.deepcopy(template_grain)  # make a copy as the template defaults will be updated
         self.input_data = input_data
         self.input_data_buffer = bytearray()
@@ -90,7 +90,7 @@ class H264GrainWrapper(object):
                     break
 
             if frame_size is not None and frame_size > 0:
-                assert(nalu_byte_offsets is not None)
+                assert (nalu_byte_offsets is not None)
 
                 frame_data = self.input_data_buffer[:frame_size]
                 yield (frame_data, list(nalu_byte_offsets), frame_info)

--- a/mediagrains/utils/h264_parser.py
+++ b/mediagrains/utils/h264_parser.py
@@ -243,7 +243,7 @@ class H264Parser(object):
                     pps = self._parse_pps(rbsp_bits)
                     self.pps_sets[pps.pic_parameter_set_id] = pps
 
-                assert(offset is not None)
+                assert (offset is not None)
                 nalu_byte_offsets.append(offset//8)
                 offset = next_offset
 
@@ -254,7 +254,7 @@ class H264Parser(object):
 
                 # The NALU offsets assumes 3-byte start codes but the start of the frame should have 4 and
                 # so the next frame start should be at next_offset - 1
-                assert(offset is not None)
+                assert (offset is not None)
                 frame_size = offset//8
                 if frame_size > 0 and frame_data[frame_size - 1] == 0:
                     frame_size -= 1


### PR DESCRIPTION
# Details
Fixes lint failure that comes up in newer versions of flake8 because spaces are now required after keywords

# Pivotal Story
Story URL: https://www.pivotaltracker.com/story/show/182866165

# Related PRs
N/A

# Links to external test runs/working deployment
N/A

# Submitter PR Checks
_(tick as appropriate)_

- [X] Added bbc/rd-apmm-cloudfit team as a reviewer
- [X] PR completes task/fixes bug
- [ ] Tests exercise code appropriately
- [ ] New features and API breaks are flagged in commit messages using magic strings
- [ ] Repo maintainer is notified that a release is required
- [ ] Documentation updated (README, Confluence, Docstrings, API spec, Engineering Guide, etc.)
- [ ] Downstream repos have been checked for potential breaks & fixed as needed
- [ ] APIs/UIs/CLIs updated as required
- [X] PR added to Pivotal story
- [ ] Follow-up stories added to Pivotal
- [ ] Any temporary code/configuration removed (e.g. test deployment environment, temporary commontooling branch)
- [ ] Any pins against pre-releases have been removed

# Reviewer PR Checks
_(tick as appropriate)_

- [ ] PR completes task/fixes bug
- [ ] Tests exercise code appropriately
- [ ] Design makes sense, and fits with our current code base
- [ ] Code is easy to follow
- [ ] PR size is sensible
- [ ] Commit history is sensible and tidy

# Info on Cloudfit PRs
- The checks above are guidelines. They don't all have to be ticked, but they should all have been considered.
- For more details on how to asses PRs, see: https://github.com/bbc/rd-apmm-docs-ways-of-working/blob/master/workflow/PRChecklist.md
