### PR TITLE
Pin python back to work around mypy issue

### DIFF
--- a/Dockerfile_multi.j2
+++ b/Dockerfile_multi.j2
@@ -2,9 +2,9 @@
 
 {{ macros.preamble() }}
 
-{{ macros.source() }}
+{{ macros.source(base_image="python:3.10.6") }}
 
-{{ macros.layer(entrypoint=False) }}
+{{ macros.layer(entrypoint=False,base_image="python:3.10.6") }}
 
 {{ macros.testdeps() }}
 


### PR DESCRIPTION
# Details
Python 3.10.7 seems to have caused issues with type checking of numpy. In particular, mypy is throwing the following error:
```
/usr/local/lib/python3.10/site-packages/numpy/__init__.pyi:636: error: Positional-only parameters are only supported in Python 3.8 and greater  [syntax]
```

This PR pins back python to 3.10.6. A ticket will be added to pivotal to investigate further. 

# Pivotal Story
Story URL:

# Related PRs
_Where appropriate. Indicate order to be merged._

# Links to external test runs/working deployment
_Where appropriate, if separate to default CI run_

# Submitter PR Checks
_(tick as appropriate)_

- [ ] Added bbc/rd-apmm-cloudfit team as a reviewer
- [ ] PR completes task/fixes bug
- [ ] Tests exercise code appropriately
- [ ] New features and API breaks are flagged in commit messages using magic strings
- [ ] Repo maintainer is notified that a release is required
- [ ] Documentation updated (README, Confluence, Docstrings, API spec, Engineering Guide, etc.)
- [ ] Downstream repos have been checked for potential breaks & fixed as needed
- [ ] APIs/UIs/CLIs updated as required
- [ ] PR added to Pivotal story
- [ ] Follow-up stories added to Pivotal
- [ ] Any temporary code/configuration removed (e.g. test deployment environment, temporary commontooling branch)
- [ ] Any pins against pre-releases have been removed

# Reviewer PR Checks
_(tick as appropriate)_

- [ ] PR completes task/fixes bug
- [ ] Tests exercise code appropriately
- [ ] Design makes sense, and fits with our current code base
- [ ] Code is easy to follow
- [ ] PR size is sensible
- [ ] Commit history is sensible and tidy

# Info on Cloudfit PRs
- The checks above are guidelines. They don't all have to be ticked, but they should all have been considered.
- For more details on how to asses PRs, see: https://github.com/bbc/rd-apmm-docs-ways-of-working/blob/master/workflow/PRChecklist.md
