### PR TITLE
gsf_probe: Add an option to print all timestamps

### DIFF
--- a/mediagrains/tools/extract_from_gsf.py
+++ b/mediagrains/tools/extract_from_gsf.py
@@ -55,6 +55,8 @@ def gsf_probe():
     )
 
     parser.add_argument("input_file", help="Input file. Specify - for stdin", type=str)
+    parser.add_argument("-a", "--all-timestamps", help="Print all the grain timestamps in the file",
+                        action="store_true")
 
     args = parser.parse_args()
 
@@ -74,5 +76,17 @@ def gsf_probe():
             except KeyError:
                 this_segment["timerange"] = grain.origin_timerange()
                 this_segment["grain_data"] = grain.meta["grain"]
+
+            if args.all_timestamps:
+                grain_ts_data = {
+                    "origin_timestamp": grain.origin_timestamp,
+                    "sync_timestamp": grain.sync_timestamp,
+                    "creation_timestamp": grain.creation_timestamp
+                }
+
+                try:
+                    this_segment["grain_timestamps"].append(grain_ts_data)
+                except KeyError:
+                    this_segment["grain_timestamps"] = [grain_ts_data]
 
         print(mediajson.dumps(file_data, indent=True))


### PR DESCRIPTION
# Details
Adds a flag to `gsf_probe` to print all the timestamps in the GSF file, rather than just the first grain. Useful sometimes when hunting for timing oddities (e.g. the Kiloview S2 dropping 1 frame every second - which is why it got written)

# Pivotal Story
Story URL: N/A (written while hunting another bug)

# Related PRs
N/A

# Links to external test runs/working deployment
Tested on various GSF files out of Squirrel

# Submitter PR Checks
_(tick as appropriate)_

- [X] Added bbc/rd-apmm-cloudfit team as a reviewer
- [X] PR completes task/fixes bug
- [ ] Tests exercise code appropriately
- [ ] New features and API breaks are flagged in commit messages using magic strings
- [ ] Repo maintainer is notified that a release is required
- [ ] Documentation updated (README, Confluence, Docstrings, API spec, Engineering Guide, etc.)
- [ ] Downstream repos have been checked for potential breaks & fixed as needed
- [ ] APIs/UIs/CLIs updated as required
- [ ] PR added to Pivotal story
- [ ] Follow-up stories added to Pivotal
- [ ] Any temporary code/configuration removed (e.g. test deployment environment, temporary commontooling branch)
- [ ] Any pins against pre-releases have been removed

# Reviewer PR Checks
_(tick as appropriate)_

- [ ] PR completes task/fixes bug
- [ ] Tests exercise code appropriately
- [ ] Design makes sense, and fits with our current code base
- [ ] Code is easy to follow
- [ ] PR size is sensible
- [ ] Commit history is sensible and tidy

# Info on Cloudfit PRs
- The checks above are guidelines. They don't all have to be ticked, but they should all have been considered.
- For more details on how to asses PRs, see: https://github.com/bbc/rd-apmm-docs-ways-of-working/blob/master/workflow/PRChecklist.md
