### PR TITLE
Ignore broken frozendict typing

### DIFF
--- a/mediagrains/gsf.py
+++ b/mediagrains/gsf.py
@@ -1563,7 +1563,7 @@ class OpenGSFEncoderBase(object):
 
     @property
     def segments(self) -> Mapping[int, "GSFEncoderSegment"]:
-        return frozendict(self._segments)
+        return frozendict(self._segments)  # type: ignore[operator]
 
     def add_tag(self, key: str, value: str):
         """Add a tag to the file"""
@@ -1969,7 +1969,7 @@ class GSFEncoder(object):
 
     @property
     def segments(self) -> Mapping[int, "GSFEncoderSegment"]:
-        return frozendict(self._segments)
+        return frozendict(self._segments)  # type: ignore[operator]
 
     def add_tag(self, key: str, value: str):
         """Add a tag to the file"""


### PR DESCRIPTION
# Details
Frozendict still doesn't support python typing. A recent release (on frozendict or mypy?) meant our previous type ignores were no longer working. Add in more specific ignores to work around this issue. There is an [existing ticket](https://www.pivotaltracker.com/story/show/180933852) to re-introduce frozendict typing once it is properly supported.

# Pivotal Story
Story URL:

# Related PRs
_Where appropriate. Indicate order to be merged._

# Links to external test runs/working deployment
_Where appropriate, if separate to default CI run_

# Submitter PR Checks
_(tick as appropriate)_

- [ ] Added bbc/rd-apmm-cloudfit team as a reviewer
- [ ] PR completes task/fixes bug
- [ ] Tests exercise code appropriately
- [ ] New features and API breaks are flagged in commit messages using magic strings
- [ ] Repo maintainer is notified that a release is required
- [ ] Documentation updated (README, Confluence, Docstrings, API spec, Engineering Guide, etc.)
- [ ] Downstream repos have been checked for potential breaks & fixed as needed
- [ ] APIs/UIs/CLIs updated as required
- [ ] PR added to Pivotal story
- [ ] Follow-up stories added to Pivotal
- [ ] Any temporary code/configuration removed (e.g. test deployment environment, temporary commontooling branch)
- [ ] Any pins against pre-releases have been removed

# Reviewer PR Checks
_(tick as appropriate)_

- [ ] PR completes task/fixes bug
- [ ] Tests exercise code appropriately
- [ ] Design makes sense, and fits with our current code base
- [ ] Code is easy to follow
- [ ] PR size is sensible
- [ ] Commit history is sensible and tidy

# Info on Cloudfit PRs
- The checks above are guidelines. They don't all have to be ticked, but they should all have been considered.
- For more details on how to asses PRs, see: https://github.com/bbc/rd-apmm-docs-ways-of-working/blob/master/workflow/PRChecklist.md
