### PR TITLE
Pin bitstring to 4.0.1 to work around type issues

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -59,7 +59,7 @@ packages_required = [
     "frozendict >= 1.2",
     'numpy >= 1.23.0',
     'deprecated >= 1.2.6',
-    "bitstring"
+    "bitstring >= 3.1.9, <= 4.0.1",
 ]
 
 console_scripts = [


### PR DESCRIPTION
(4.0.2 enables type annotations)

# Details
Pin bitstring to 4.0.1.  Bitstring release 4.0.2 enables type annotations, exposing some mismatches in h264_parser.py.

# Pivotal Story
Story URL: https://www.pivotaltracker.com/story/show/184967562

# Related PRs
_Where appropriate. Indicate order to be merged._

# Links to external test runs/working deployment
_Where appropriate, if separate to default CI run_

# Submitter PR Checks
_(tick as appropriate)_

- [x] Added bbc/rd-apmm-cloudfit team as a reviewer
- [ ] PR completes task/fixes bug
- [ ] Tests exercise code appropriately
- [ ] New features and API breaks are flagged in commit messages using magic strings
- [ ] Repo maintainer is notified that a release is required
- [ ] Documentation updated (README, Confluence, Docstrings, API spec, Engineering Guide, etc.)
- [ ] Downstream repos have been checked for potential breaks & fixed as needed
- [ ] APIs/UIs/CLIs updated as required
- [x] PR added to Pivotal story
- [x] Follow-up stories added to Pivotal
- [ ] Any temporary code/configuration removed (e.g. test deployment environment, temporary commontooling branch)
- [ ] Any pins against pre-releases have been removed

# Reviewer PR Checks
_(tick as appropriate)_

- [ ] PR completes task/fixes bug
- [ ] Tests exercise code appropriately
- [ ] Design makes sense, and fits with our current code base
- [ ] Code is easy to follow
- [ ] PR size is sensible
- [ ] Commit history is sensible and tidy

# Info on Cloudfit PRs
- The checks above are guidelines. They don't all have to be ticked, but they should all have been considered.
- For more details on how to asses PRs, see: https://github.com/bbc/rd-apmm-docs-ways-of-working/blob/master/workflow/PRChecklist.md
