### PR TITLE
Add submodules to docs

### DIFF
--- a/Dockerfile_multi.j2
+++ b/Dockerfile_multi.j2
@@ -29,4 +29,8 @@ CMD ["discover", "tests", "-v"]
 
 {{ macros.wheel() }}
 
-{{ macros.docs() }}
+{{ macros.docs(with_template=True, extra_submodules=[
+          "comparison", "grains", "numpy.numpy_grains", "patterngenerators", "patterngenerators.audio",
+          "patterngenerators.video" , "tools", "utils"
+     ])
+}}

--- a/module.html.jinja2
+++ b/module.html.jinja2
@@ -1,0 +1,27 @@
+{% extends "default/module.html.jinja2" %}
+
+{#
+Modify the SubModules block to include submodules that aren't exposed through __all__.
+These submodules need to be included in the module list passed to pdoc.
+#}
+{% block nav_submodules %}
+    {% if module.submodules or module.fullname == "mediagrains.patterngenerators" %}
+        <h2>Submodules</h2>
+        <ul>
+            {% for submodule in module.submodules if is_public(submodule) | trim %}
+                <li>{{ submodule.taken_from | link(text=submodule.name) }}</li>
+            {% endfor %}
+            {% if module.fullname == "mediagrains" %}
+                <li><a href="mediagrains/comparison.html">comparison</a></li>
+                <li><a href="mediagrains/grains.html">grains</a></li>
+                <li><a href="mediagrains/numpy/numpy_grains.html">numpy/numpy_grains</a></li>
+                <li><a href="mediagrains/patterngenerators.html">patterngenerators</a></li>
+                <li><a href="mediagrains/tools.html">tools</a></li>
+                <li><a href="mediagrains/utils.html">utils</a></li>
+            {% elif module.fullname == "mediagrains.patterngenerators" %}
+                <li><a href="patterngenerators/audio.html">audio</a></li>
+                <li><a href="patterngenerators/video.html">video</a></li>
+            {% endif %}
+        </ul>
+    {% endif %}
+{% endblock %}

--- a/static-commontooling/docker/Dockerfile_multi_macros.j2
+++ b/static-commontooling/docker/Dockerfile_multi_macros.j2
@@ -184,17 +184,31 @@ RUN chmod u+x /run_with_dir_modes.sh
 ENTRYPOINT ["/run_with_dir_modes.sh", "./dist", "python", "./setup.py", "sdist", "bdist_wheel"]
 {%- endmacro %}
 
-{% macro docs() -%}
+{% macro docs(with_template=False, extra_submodules=[]) -%}
 ###############################################################################
 # Stage: docs - Generates documentation from docstrings
 ###############################################################################
 FROM wheel AS docs
 WORKDIR /docs/
 
+# Copy the pdoc template file to the module directory
+{%   if with_template -%}
+COPY --from=source /{{ modname }}/module.html.jinja2 /{{ modname }}/
+{%-  endif %}
+
 RUN --mount=type=cache,target=/root/.cache/pip --mount=type=secret,id=forgecert pip install pdoc
 
 ENTRYPOINT ["/run_with_dir_modes.sh", ".", "pdoc"]
-CMD ["--output-directory", "{{ modname }}", "{{ modname }}"]
+CMD [ \
+    "--output-directory", "{{ modname }}", \
+{%- if with_template %}
+    "--template-dir", "/{{ modname }}", \
+{%- endif %}
+    "{{ modname }}"{{ "," if extra_submodules }} \
+{%- for extra_submodule in extra_submodules %}
+    "{{ modname }}.{{ extra_submodule }}"{{ "," if not loop.last }} \
+{%- endfor %}
+]
 {%- endmacro %}
 
 {% macro alembic() -%}


### PR DESCRIPTION
# Details
Add submodules not included in `__all__` to the generated docs. These submodules are public but users need to explicitly import them.

Rendered docs: https://apmm-docs.virt.ch.bbc.co.uk/rd-apmm-python-lib-mediagrains/docs/mediagrains/mediagrains.html

TODO: remove commontooling TEMP commit once https://github.com/bbc/rd-cloudfit-commontooling/pull/229 has been merged into main.

# Pivotal Story
Story URL: https://www.pivotaltracker.com/story/show/185079553

# Related PRs
Requires https://github.com/bbc/rd-cloudfit-commontooling/pull/229

# Links to external test runs/working deployment
_Where appropriate, if separate to default CI run_

# Submitter PR Checks
_(tick as appropriate)_

- [x] Added bbc/rd-apmm-cloudfit team as a reviewer
- [x] PR completes task/fixes bug
- [ ] Tests exercise code appropriately
- [ ] New features and API breaks are flagged in commit messages using magic strings
- [ ] Repo maintainer is notified that a release is required
- [ ] Documentation updated (README, Confluence, Docstrings, API spec, Engineering Guide, etc.)
- [ ] Downstream repos have been checked for potential breaks & fixed as needed
- [ ] APIs/UIs/CLIs updated as required
- [x] PR added to Pivotal story
- [ ] Follow-up stories added to Pivotal
- [ ] Any temporary code/configuration removed (e.g. test deployment environment, temporary commontooling branch)
- [ ] Any pins against pre-releases have been removed

# Reviewer PR Checks
_(tick as appropriate)_

- [ ] PR completes task/fixes bug
- [ ] Tests exercise code appropriately
- [ ] Design makes sense, and fits with our current code base
- [ ] Code is easy to follow
- [ ] PR size is sensible
- [ ] Commit history is sensible and tidy

# Info on Cloudfit PRs
- The checks above are guidelines. They don't all have to be ticked, but they should all have been considered.
- For more details on how to asses PRs, see: https://github.com/bbc/rd-apmm-docs-ways-of-working/blob/master/workflow/PRChecklist.md
