### PR TITLE
Add explicit unsafe casting for numpy.clip calls

### DIFF
--- a/mediagrains/numpy/convert.py
+++ b/mediagrains/numpy/convert.py
@@ -152,6 +152,7 @@ def _convert_rgb_to_yuv444(grain_in: VideoGrain, grain_out: VideoGrain) -> None:
                  grain_in.component_data.G,
                  grain_in.component_data.B)
 
+    # Note that NumPy requires the `unsafe` cast here due to the slight loss of precision in RGB<->YUV conversion
     np.clip((R*0.2126 + G*0.7152 + B*0.0722),
             0, 1 << bd, out=grain_out.component_data.Y, casting="unsafe")  # type: ignore
     np.clip((R*-0.114572 - G*0.385428 + B*0.5 + (1 << (bd - 1))),  # type: ignore
@@ -166,6 +167,7 @@ def _convert_yuv444_to_rgb(grain_in: VideoGrain, grain_out: VideoGrain) -> None:
                  grain_in.component_data.U.astype(np.dtype(np.double)) - (1 << (bd - 1)),
                  grain_in.component_data.V.astype(np.dtype(np.double)) - (1 << (bd - 1)))
 
+    # Note that NumPy requires the `unsafe` cast here due to the slight loss of precision in RGB<->YUV conversion
     np.clip((Y + V*1.5748),
             0, 1 << bd, out=grain_out.component_data.R, casting="unsafe")  # type: ignore
     np.clip((Y - U*0.187324 - V*0.468124),

--- a/mediagrains/numpy/convert.py
+++ b/mediagrains/numpy/convert.py
@@ -152,11 +152,12 @@ def _convert_rgb_to_yuv444(grain_in: VideoGrain, grain_out: VideoGrain) -> None:
                  grain_in.component_data.G,
                  grain_in.component_data.B)
 
-    np.clip((R*0.2126 + G*0.7152 + B*0.0722), 0, 1 << bd, out=grain_out.component_data.Y)
-    np.clip((R*-0.114572 - G*0.385428 + B*0.5 + (1 << (bd - 1))),
-            0, 1 << bd, out=grain_out.component_data.U)
-    np.clip((R*0.5 - G*0.454153 - B*0.045847 + (1 << (bd - 1))),
-            0, 1 << bd, out=grain_out.component_data.V)
+    np.clip((R*0.2126 + G*0.7152 + B*0.0722),
+            0, 1 << bd, out=grain_out.component_data.Y, casting="unsafe")  # type: ignore
+    np.clip((R*-0.114572 - G*0.385428 + B*0.5 + (1 << (bd - 1))),  # type: ignore
+            0, 1 << bd, out=grain_out.component_data.U, casting="unsafe")
+    np.clip((R*0.5 - G*0.454153 - B*0.045847 + (1 << (bd - 1))),  # type: ignore
+            0, 1 << bd, out=grain_out.component_data.V, casting="unsafe")
 
 
 def _convert_yuv444_to_rgb(grain_in: VideoGrain, grain_out: VideoGrain) -> None:
@@ -165,9 +166,12 @@ def _convert_yuv444_to_rgb(grain_in: VideoGrain, grain_out: VideoGrain) -> None:
                  grain_in.component_data.U.astype(np.dtype(np.double)) - (1 << (bd - 1)),
                  grain_in.component_data.V.astype(np.dtype(np.double)) - (1 << (bd - 1)))
 
-    np.clip((Y + V*1.5748), 0, 1 << bd, out=grain_out.component_data.R)
-    np.clip((Y - U*0.187324 - V*0.468124), 0, 1 << bd, out=grain_out.component_data.G)
-    np.clip((Y + U*1.8556), 0, 1 << bd, out=grain_out.component_data.B)
+    np.clip((Y + V*1.5748),
+            0, 1 << bd, out=grain_out.component_data.R, casting="unsafe")  # type: ignore
+    np.clip((Y - U*0.187324 - V*0.468124),
+            0, 1 << bd, out=grain_out.component_data.G, casting="unsafe")  # type: ignore
+    np.clip((Y + U*1.8556),
+            0, 1 << bd, out=grain_out.component_data.B, casting="unsafe")  # type: ignore
 
 
 def _convert_v210_to_yuv422_10bit(grain_in: VideoGrain, grain_out: VideoGrain) -> None:


### PR DESCRIPTION
# Details
numpy 1.25.0 removed deprecation from numpy.clip that allowed a fallback to unsafe casts. The default < 1.7 used to be "unsafe" and it was changed to "same_kind" from 1.10.

See the [Default casting rule change in 1.10](https://numpy.org/devdocs/release/1.10.0-notes.html#default-casting-rule-change) for a short explanation of why it was changed. A non-"same kind" cast is seen to likely be a bug. An "unsafe" cast (precision loss) is expected in this case when converting float to int in the RGB<->YUV conversions.

See the [numpy type casting rules](https://numpy.org/doc/stable/user/basics.ufuncs.html#type-casting-rules) and [can_cast](https://numpy.org/doc/stable/reference/generated/numpy.can_cast.html) for the meaning of the `casting` arg.

# Pivotal Story
Story URL:

# Related PRs
_Where appropriate. Indicate order to be merged._

# Links to external test runs/working deployment
_Where appropriate, if separate to default CI run_

# Submitter PR Checks
_(tick as appropriate)_

- [ ] Added bbc/rd-apmm-cloudfit team as a reviewer
- [ ] PR completes task/fixes bug
- [ ] Tests exercise code appropriately
- [ ] New features and API breaks are flagged in commit messages using magic strings
- [ ] Repo maintainer is notified that a release is required
- [ ] Documentation updated (README, Confluence, Docstrings, API spec, Engineering Guide, etc.)
- [ ] Downstream repos have been checked for potential breaks & fixed as needed
- [ ] APIs/UIs/CLIs updated as required
- [ ] PR added to Pivotal story
- [ ] Follow-up stories added to Pivotal
- [ ] Any temporary code/configuration removed (e.g. test deployment environment, temporary commontooling branch)
- [ ] Any pins against pre-releases have been removed

# Reviewer PR Checks
_(tick as appropriate)_

- [ ] PR completes task/fixes bug
- [ ] Tests exercise code appropriately
- [ ] Design makes sense, and fits with our current code base
- [ ] Code is easy to follow
- [ ] PR size is sensible
- [ ] Commit history is sensible and tidy

# Info on Cloudfit PRs
- The checks above are guidelines. They don't all have to be ticked, but they should all have been considered.
- For more details on how to asses PRs, see: https://github.com/bbc/rd-apmm-docs-ways-of-working/blob/master/workflow/PRChecklist.md
