### PR TITLE
gsf: restore flow block data as string

### DIFF
--- a/mediagrains/gsf.py
+++ b/mediagrains/gsf.py
@@ -777,7 +777,7 @@ class BaseGSFDecoderSession(object):
                                 'source_id': src_id,
                                 'flow_id': flow_id,
                                 'format': format,
-                                'data': data
+                                'data': data.decode('utf-8')
                             }
                         elif segm_child.tag == "tag ":
                             key = segm_child.read_varstring()

--- a/static-commontooling/docker/Dockerfile_multi_macros.j2
+++ b/static-commontooling/docker/Dockerfile_multi_macros.j2
@@ -104,7 +104,7 @@ COPY wheels/ ./wheels
 # Install test requirements
 COPY constraints.txt ./
 COPY test-requirements.txt ./
-RUN --mount=type=cache,target=/root/.cache/pip --mount=type=secret,id=forgecert python -m pip install -f ./wheels --user -c constraints.txt -r ./test-requirements.txt flake8 "mypy>=0.910"
+RUN --mount=type=cache,target=/root/.cache/pip --mount=type=secret,id=forgecert python -m pip install -f ./wheels --user -c constraints.txt -r ./test-requirements.txt flake8 "mypy>=1.4.1"
 {%- endmacro %}
 
 {% macro tests(include_extra_layers=[]) -%}


### PR DESCRIPTION
# Details
Allows flow data to be output as JSON (e.g. by `gsf_probe`), which is not supported if it was kept as bytes.

# Pivotal Story
Story URL: https://www.pivotaltracker.com/story/show/184557184

# Related PRs
_Where appropriate. Indicate order to be merged._

# Links to external test runs/working deployment
_Where appropriate, if separate to default CI run_

# Submitter PR Checks
_(tick as appropriate)_

- [x] Added bbc/rd-apmm-cloudfit team as a reviewer
- [x] PR completes task/fixes bug
- [ ] Tests exercise code appropriately
- [ ] New features and API breaks are flagged in commit messages using magic strings
- [ ] Repo maintainer is notified that a release is required
- [ ] Documentation updated (README, Confluence, Docstrings, API spec, Engineering Guide, etc.)
- [ ] Downstream repos have been checked for potential breaks & fixed as needed
- [ ] APIs/UIs/CLIs updated as required
- [x] PR added to Pivotal story
- [ ] Follow-up stories added to Pivotal
- [ ] Any temporary code/configuration removed (e.g. test deployment environment, temporary commontooling branch)
- [ ] Any pins against pre-releases have been removed

# Reviewer PR Checks
_(tick as appropriate)_

- [ ] PR completes task/fixes bug
- [ ] Tests exercise code appropriately
- [ ] Design makes sense, and fits with our current code base
- [ ] Code is easy to follow
- [ ] PR size is sensible
- [ ] Commit history is sensible and tidy

# Info on Cloudfit PRs
- The checks above are guidelines. They don't all have to be ticked, but they should all have been considered.
- For more details on how to asses PRs, see: https://github.com/bbc/rd-apmm-docs-ways-of-working/blob/master/workflow/PRChecklist.md
