### PR TITLE
Only push latest on release

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,10 +1,16 @@
 MS_DOCKER_PUSH:=TRUE
-MS_DOCKER_PUSH_LATEST:=TRUE
 DOCKER_REPO:=public.ecr.aws/o4o2s1w1/cloudfit
 
 include ./static-commontooling/make/lib_static_commontooling.mk
 include ./static-commontooling/make/standalone.mk
 include ./static-commontooling/make/pythonic.mk
+
+
+# Only push latest tag if this version is a release (so there's no next version yet)
+ifeq "${VERSION}" "${NEXT_VERSION}"
+MS_DOCKER_PUSH_LATEST:=TRUE
+endif
+
 include ./static-commontooling/make/docker.mk
 
 all: tools-help


### PR DESCRIPTION
# Details
Based on change at https://github.com/bbc/rd-cloudfit-deployment/commit/98b11e0.
Will be released to fix a problem where the current mediagrains Docker image contains the new GSF version, which is breaking some of Weasel's CI

# Pivotal Story
Story URL: N/A: CI failure

# Related PRs
Required by https://github.com/bbc/rd-cloudfit-weasel-recipe-examples/pull/36

# Links to external test runs/working deployment
N/A

# Submitter PR Checks
_(tick as appropriate)_

- [X] Added bbc/rd-apmm-cloudfit team as a reviewer
- [X] PR completes task/fixes bug
- [ ] Tests exercise code appropriately
- [ ] New features and API breaks are flagged in commit messages using magic strings
- [X] Repo maintainer is notified that a release is required
- [ ] Documentation updated (README, Confluence, Docstrings, API spec, Engineering Guide, etc.)
- [ ] Downstream repos have been checked for potential breaks & fixed as needed
- [ ] APIs/UIs/CLIs updated as required
- [ ] PR added to Pivotal story
- [ ] Follow-up stories added to Pivotal
- [ ] Any temporary code/configuration removed (e.g. test deployment environment, temporary commontooling branch)
- [ ] Any pins against pre-releases have been removed

# Reviewer PR Checks
_(tick as appropriate)_

- [ ] PR completes task/fixes bug
- [ ] Tests exercise code appropriately
- [ ] Design makes sense, and fits with our current code base
- [ ] Code is easy to follow
- [ ] PR size is sensible
- [ ] Commit history is sensible and tidy

# Info on Cloudfit PRs
- The checks above are guidelines. They don't all have to be ticked, but they should all have been considered.
- For more details on how to asses PRs, see: https://github.com/bbc/rd-apmm-docs-ways-of-working/blob/master/workflow/PRChecklist.md
