### PR TITLE
Unpin bitstring and fix related h264_parser issues

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -58,7 +58,7 @@ packages_required = [
     "frozendict >= 1.2",
     'numpy >= 1.23.0',
     'deprecated >= 1.2.6',
-    "bitstring >= 4.0.1, < 4.1.0",  # Ticket to remove pin https://www.pivotaltracker.com/story/show/185860418
+    "bitstring >= 4.1.0"
 ]
 
 console_scripts = [


### PR DESCRIPTION
# Details
This PR unpins `bitstring` and fixes the issues seen:
* the bits `append` calls in `_parse_rbsp_bits` positions the stream at the end. Fixed by setting pos to 0 before returning
  * this changed behaviour is documented in https://bitstring.readthedocs.io/en/stable/bitstream.html
* changed `Bits` to `ConstBitStream` types to signal to mypy that the `pos` attribute is present. The type is actually `BitStream` -> `ConstBitStream` -> `Bits`
* Use `iter()` on the bits `findall` result to fix typing and to follow bitstring's typing where the return value is an `Iterable` even though it is actually a generator.# Pivotal Story

@j616 a release will be required.

# Pivotal Story
Story URL: https://www.pivotaltracker.com/story/show/185860418

# Related PRs
_Where appropriate. Indicate order to be merged._

# Links to external test runs/working deployment
_Where appropriate, if separate to default CI run_

# Submitter PR Checks
_(tick as appropriate)_

- [ ] Added bbc/rd-apmm-cloudfit team as a reviewer
- [ ] PR completes task/fixes bug
- [ ] Tests exercise code appropriately
- [ ] New features and API breaks are flagged in commit messages using magic strings
- [ ] Repo maintainer is notified that a release is required
- [ ] Documentation updated (README, Confluence, Docstrings, API spec, Engineering Guide, etc.)
- [ ] Downstream repos have been checked for potential breaks & fixed as needed
- [ ] APIs/UIs/CLIs updated as required
- [ ] PR added to Pivotal story
- [ ] Follow-up stories added to Pivotal
- [ ] Any temporary code/configuration removed (e.g. test deployment environment, temporary commontooling branch)
- [ ] Any pins against pre-releases have been removed

# Reviewer PR Checks
_(tick as appropriate)_

- [ ] PR completes task/fixes bug
- [ ] Tests exercise code appropriately
- [ ] Design makes sense, and fits with our current code base
- [ ] Code is easy to follow
- [ ] PR size is sensible
- [ ] Commit history is sensible and tidy

# Info on Cloudfit PRs
- The checks above are guidelines. They don't all have to be ticked, but they should all have been considered.
- For more details on how to asses PRs, see: https://github.com/bbc/rd-apmm-docs-ways-of-working/blob/master/workflow/PRChecklist.md
