### PR TITLE
Fix typing following mypy become more strict on bytes-like types

### DIFF
--- a/mediagrains/typing.py
+++ b/mediagrains/typing.py
@@ -261,7 +261,7 @@ GrainMetadataDict = Union[
 
 
 # This is the type that defines what can go in a grain data element, there may be some corner cases not covered by this
-GrainDataType = Union[SupportsBytes, bytes, ndarray]
+GrainDataType = Union[SupportsBytes, bytearray, bytes, ndarray]
 
 GrainDataParameterType = Optional[Union[GrainDataType, Awaitable[Optional[GrainDataType]]]]
 

--- a/mediagrains/utils/h264_grain_wrapper.py
+++ b/mediagrains/utils/h264_grain_wrapper.py
@@ -78,7 +78,7 @@ class H264GrainWrapper(object):
                     if data:
                         self.input_data_buffer += data
 
-                (frame_size, nalu_byte_offsets, frame_info) = h264_parser.parse_frame(self.input_data_buffer)
+                (frame_size, nalu_byte_offsets, frame_info) = h264_parser.parse_frame(bytes(self.input_data_buffer))
 
                 if frame_size is not None:
                     # Parsed a new frame
@@ -93,17 +93,17 @@ class H264GrainWrapper(object):
                 assert (nalu_byte_offsets is not None)
 
                 frame_data = self.input_data_buffer[:frame_size]
-                yield (frame_data, list(nalu_byte_offsets), frame_info)
+                yield (bytes(frame_data), list(nalu_byte_offsets), frame_info)
 
                 self.input_data_buffer = self.input_data_buffer[frame_size:]
 
         # Assume the remainder is a frame an yield it if there are NAL units
         if len(self.input_data_buffer) > 0:
             frame_data = self.input_data_buffer
-            unit_offsets = list(h264_parser.get_nalu_byte_offsets(frame_data))
+            unit_offsets = list(h264_parser.get_nalu_byte_offsets(bytes(frame_data)))
             if len(unit_offsets) > 0:
-                frame_info = h264_parser.parse_frame_info(frame_data, nalu_byte_offsets=unit_offsets)
-                yield (frame_data, unit_offsets, frame_info)
+                frame_info = h264_parser.parse_frame_info(bytes(frame_data), nalu_byte_offsets=unit_offsets)
+                yield (bytes(frame_data), unit_offsets, frame_info)
 
     def grains(self) -> typing.Iterator[CodedVideoGrain]:
         """Generator that yields Grains read from the input given


### PR DESCRIPTION
# Details
Fix typing following [mypy become more strict on bytes-like types](https://mypy.readthedocs.io/en/stable/changelog.html#enable-strict-bytes-by-default)

# Jira Issue
Jira URL:

# Related PRs
_Where appropriate. Indicate order to be merged._

# Links to external test runs/working deployment
_Where appropriate, if separate to default CI run_

# Submitter PR Checks
_(tick as appropriate)_

- [ ] PR completes task/fixes bug
- [ ] Tests exercise code appropriately
- [ ] New features and API breaks are flagged in commit messages using magic strings
- [ ] Documentation updated (README, Confluence, Docstrings, API spec, Engineering Guide, etc.)
- [ ] Downstream repos have been checked for potential breaks & fixed as needed
- [ ] APIs/UIs/CLIs updated as required
- [ ] PR added to Jira Issue
- [ ] Follow-up stories added to Jira
- [ ] Any temporary code/configuration removed (e.g. test deployment environment, temporary commontooling branch)
- [ ] Any pins against pre-releases have been removed

# Reviewer PR Checks
_(tick as appropriate)_

- [ ] PR completes task/fixes bug
- [ ] Tests exercise code appropriately
- [ ] Design makes sense, and fits with our current code base
- [ ] Code is easy to follow
- [ ] PR size is sensible
- [ ] Commit history is sensible and tidy

# Info on Cloudfit PRs
- The checks above are guidelines. They don't all have to be ticked, but they should all have been considered.
- For more details on how to asses PRs, see: https://github.com/bbc/rd-apmm-docs-ways-of-working/blob/master/workflow/PRChecklist.md
